### PR TITLE
fix(exec): escape braces in MDX table cells to fix CI build error

### DIFF
--- a/docs/configuration/exec.md
+++ b/docs/configuration/exec.md
@@ -112,7 +112,7 @@ The full list of blocked patterns includes:
 | Bulk deletion | `rm -rf`, `del /f/q`, `rmdir /s` |
 | Disk operations | `format`, `mkfs`, `diskpart`, `dd if=`, writes to block devices (`/dev/sd*`, `/dev/hd*`, `/dev/vd*`, `/dev/xvd*`, `/dev/nvme*`, `/dev/mmcblk*`, `/dev/loop*`, `/dev/dm-*`, `/dev/md*`, `/dev/sr*`, `/dev/nbd*`) |
 | System control | `shutdown`, `reboot`, `poweroff` |
-| Fork bomb | `:(){ :|:& };:` |
+| Fork bomb | `:(){ :\|:& };:` |
 | **Shell substitution** | **`$(...)`, `${...}`, backticks**, `$(cat ...)`, `$(curl ...)`, `$(wget ...)`, `$(which ...)` |
 | Chained deletion | `; rm -rf`, `&& rm -rf`, `\|\| rm -rf` |
 | Pipe to shell | `\| sh`, `\| bash` |
@@ -126,7 +126,7 @@ The full list of blocked patterns includes:
 | Other | `eval`, `source *.sh` |
 
 :::caution Common False Positive: Shell Variable Syntax
-The rule `\$\{[^}]+\}` blocks **any** command containing `${...}`, including legitimate bash default-value syntax like `${VAR:-default}`. This is a known trade-off — the pattern was added to prevent variable injection attacks.
+The rule `\$\{[^\}]+\}` blocks **any** command containing `${...}`, including legitimate bash default-value syntax like `${VAR:-default}`. This is a known trade-off — the pattern was added to prevent variable injection attacks.
 
 Error message you will see:
 ```


### PR DESCRIPTION
Fixes the MDX compilation error introduced in #42.

## Problem

MDX parses {...} inside table cells as JSX expressions even within inline code spans. The fork bomb example ` :(){ :|:& };: ` on line 115 caused:

`
Unexpected end of file in expression, expected a corresponding closing brace for {
`

## Fix

Escape the pipe inside the fork bomb pattern (:\|) so MDX does not attempt to parse the braces as a JSX expression. Also escape the closing brace in the caution callout regex example.