### PR TITLE
docs(changelog): sync v0.2.7 release notes across locales

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,62 @@ All notable changes to PicoClaw are documented here.
 
 ---
 
+## v0.2.7
+
+*Released: 2026-04-22*
+
+### Highlights
+
+- **Launcher auth flow upgrade**: Unified dashboard `/login` / `/setup` / `/logout` flow, added OAuth `--no-browser` login, and migrated launcher auth to password mode (#2339, #2549, #2608)
+- **Agent Loop two-phase refactor**: Split and reorganized the core loop pipeline to reduce maintenance complexity and prepare for parallel execution capabilities (#2564, #2585)
+- **Native Gemini provider**: Added native Gemini provider support and separated thought-message handling from output-message handling (#2475)
+- **Toolchain and session stability improvements**: Added `/context` command and context usage indicator; `/clear` now supports Seahorse DB cleanup; scheduled tasks now run in isolated sessions (#2537, #2495, #2474)
+- **Web UI UX improvements**: Refactored tools page into tabbed Library/Settings views, improved Markdown highlighting, and completed disabled-state reason hints (#2539, #2529, #2523, #2430, #2526)
+- **Search and network robustness improvements**: Added configurable Sogou search backend and improved proxying, error classification, and fallback behavior (#2524, #2542, #2547, #2517)
+
+### Features
+
+#### Core & Agent
+- **Loop refactor**: Completed Phase 1/2 loop file split and execution-pipeline reordering (#2564, #2585)
+- **LLM-as-Judge**: Added new evaluation mode (#2484)
+- **Parallel execution evolution**: Continued enabling parallel-execution scenarios in the agent loop (#2503)
+
+#### Providers & Auth
+- **Native Gemini protocol support**: Native provider plus thought/output separation (#2475)
+- **OAuth login UX**: Added `--no-browser` option for headless/no-GUI environments (#2549)
+- **Auth compatibility improvements**: Disabled token-auth fallback on unsupported platforms; fixed Google Antigravity provider normalization and credential consistency (#2466, #2599)
+
+#### Channels, Tools & Interaction
+- **Multi-instance channel config evolution**: Moved toward a multi-instance configuration model, fixed nested `channel_list` patch persistence, and improved list editing (#2481, #2530, #2595)
+- **Tool call consistency**: Fixed cross-turn tool-call ID reuse; kept tool call summaries and assistant output in sync (#2528, #2449)
+- **Disabled-state messaging**: Expanded composer/tooltip disabled-reason hints and fixed related regressions (#2523, #2430, #2526)
+
+### Bug Fixes
+
+- **Runtime recovery**: Fixed MCP/discovery tool recovery after reload; fixed recovery after `image-input-unsupported` errors (#2489, #2525)
+- **Seahorse search safety**: Fixed FTS5 MATCH input sanitization issue (#2436)
+- **Release/update stability**: Fixed retry behavior for transient release-info fetch failures; improved pre-start error logging (#2511, #2414)
+- **Config and network edge cases**: Fixed `allowFrom` containing empty-string values; improved network error classification and fallback handling (#2507, #2547)
+- **Frontend stability**: Fixed config refresh resetting search drafts; cleaned recovered session transcripts and improved chat UI (#2536, #2605)
+- **Engineering quality fixes**: Fixed `govet` shadow warnings and adjusted isolation tests on unsupported operating systems (#2613, #2434)
+
+### Build & Ops
+
+- **Android release pipeline**: Added Android arm64 cross-compilation and integrated Android bundle publishing into GoReleaser (#2486, #2497)
+- **CI workflow updates**: Switched to `pnpm/action-setup` and updated README installation steps (#2512, #2552)
+- **Dependency maintenance**: Upgraded multiple frontend/backend dependencies (React, TanStack, shadcn, sqlite, MCP SDK, router/lint, and others)
+- **Container behavior parity**: Changed self-built images to run as root to match release image behavior (#2435)
+
+### Documentation
+
+- **Docs structure reorganization**: Reorganized docs by type and added layout guide plus session/routing docs (#2567, #2571)
+- **Protocol docs updates**: Updated native Gemini protocol docs and cross-provider JSON escaping guidance (#2601, #2420)
+- **Localization and misc fixes**: Added Korean README; fixed Conventional Commits link in CONTRIBUTING (#2418, #2494)
+
+### Full changelog
+- [GitHub v0.2.6...v0.2.7](https://github.com/sipeed/picoclaw/compare/v0.2.6...v0.2.7)
+---
+
 ## v0.2.6
 
 *Released: 2026-04-08*

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/changelog.md
@@ -9,6 +9,62 @@ Todas as mudanças notáveis do PicoClaw são documentadas aqui.
 
 ---
 
+## v0.2.7
+
+*Lançado: 2026-04-22*
+
+### Destaques
+
+- **Upgrade no fluxo de autenticação do Launcher**: Fluxo unificado de `/login` / `/setup` / `/logout` no dashboard, novo login OAuth com `--no-browser`, e migração da autenticação do launcher para modo senha (#2339, #2549, #2608)
+- **Refatoração em duas fases do Agent Loop**: Divisão e reorganização do pipeline central de loop para reduzir complexidade de manutenção e preparar suporte a execução paralela (#2564, #2585)
+- **Provider Gemini nativo**: Novo provider Gemini nativo com separação entre mensagens de thought e mensagens de output (#2475)
+- **Melhorias de estabilidade em ferramentas e sessões**: Novo comando `/context` com indicador de uso de contexto; `/clear` agora limpa Seahorse DB; tarefas agendadas passam a rodar em sessões isoladas (#2537, #2495, #2474)
+- **Melhorias de UX na Web UI**: Página de ferramentas refeita em abas Biblioteca/Configurações, melhorias no highlight de Markdown e mensagens de motivo para estados desabilitados (#2539, #2529, #2523, #2430, #2526)
+- **Mais robustez em busca e rede**: Backend de busca Sogou configurável, com melhorias em proxy, classificação de erros e tratamento de fallback (#2524, #2542, #2547, #2517)
+
+### Funcionalidades
+
+#### Core & Agent
+- **Refatoração de Loop**: Conclusão das fases 1/2 com divisão de arquivos e reorganização do pipeline de execução (#2564, #2585)
+- **LLM-as-Judge**: Novo modo de avaliação (#2484)
+- **Evolução de execução paralela**: Avanço no suporte a cenários paralelos dentro do agent loop (#2503)
+
+#### Providers e Autenticação
+- **Suporte ao protocolo Gemini nativo**: Provider nativo com separação thought/output (#2475)
+- **UX de login OAuth**: Nova opção `--no-browser` para ambientes sem GUI (#2549)
+- **Melhorias de compatibilidade de autenticação**: Sem fallback para token em plataformas sem suporte; correção de normalização e consistência de credenciais no provider Google Antigravity (#2466, #2599)
+
+#### Canais, Ferramentas e Interação
+- **Evolução para configuração multi-instância de canais**: Ajustes no modelo de configuração multi-instância, correção de persistência de patch aninhado em `channel_list` e melhorias na edição de listas (#2481, #2530, #2595)
+- **Consistência nas chamadas de ferramenta**: Correção de reutilização de tool-call ID entre turnos e sincronização entre resumo de chamadas e saída do assistant (#2528, #2449)
+- **Mensagens de estado desabilitado**: Mais explicações de bloqueio no composer/tooltip e correção de regressão relacionada (#2523, #2430, #2526)
+
+### Correções de Bugs
+
+- **Recuperação em runtime**: Correção da recuperação de MCP/discovery tools após reload e após erro `image-input-unsupported` (#2489, #2525)
+- **Segurança na busca Seahorse**: Correção da sanitização de entrada em consultas FTS5 MATCH (#2436)
+- **Estabilidade no fluxo de release/update**: Correção de retentativas em falhas transitórias na leitura de informações de release; melhorias de log antes da inicialização (#2511, #2414)
+- **Bordas de configuração e rede**: Correção de `allowFrom` contendo string vazia; melhoria da classificação de erros de rede e fallback (#2507, #2547)
+- **Estabilidade de frontend**: Correção de reset de rascunho de busca após refresh de config; limpeza de transcrições de sessão recuperadas e melhorias no chat UI (#2536, #2605)
+- **Qualidade de engenharia**: Correção de alertas de shadow no `govet` e ajuste de testes de isolamento em OS sem suporte (#2613, #2434)
+
+### Build e Ops
+
+- **Pipeline de release Android**: Novo cross-compile Android arm64 e publicação de bundle Android no GoReleaser (#2486, #2497)
+- **Atualização do fluxo de CI**: Migração para `pnpm/action-setup` e alinhamento dos passos de instalação no README (#2512, #2552)
+- **Manutenção de dependências**: Upgrade de várias dependências de frontend e backend (React, TanStack, shadcn, sqlite, MCP SDK, router/lint e outras)
+- **Paridade de comportamento em container**: Imagens self-built passam a rodar como root para alinhar com imagens de release (#2435)
+
+### Documentação
+
+- **Reorganização da estrutura de docs**: Reorganização por tipo com novos docs de layout e session/routing (#2567, #2571)
+- **Atualização de docs de protocolo**: Atualização dos docs de protocolo Gemini nativo e de escaping JSON cross-provider (#2601, #2420)
+- **Localização e ajustes diversos**: Novo README em coreano e correção do link de Conventional Commits no CONTRIBUTING (#2418, #2494)
+
+### Changelog completo
+- [GitHub v0.2.6...v0.2.7](https://github.com/sipeed/picoclaw/compare/v0.2.6...v0.2.7)
+---
+
 ## v0.2.6
 
 *Lançado: 2026-04-08*

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/changelog.md
@@ -8,6 +8,59 @@ title: 更新日志
 PicoClaw 的所有重要更新记录。
 
 ---
+## v0.2.7
+
+*发布日期：2026-04-22*
+
+### 核心亮点
+- **Launcher 认证流程升级**：统一 dashboard 的 `/login` / `/setup` / `/logout` 流程，新增 OAuth 无浏览器登录，并将 launcher 认证迁移到密码模式（#2339、#2549、#2608）
+- **Agent Loop 两阶段重构**：拆分并重组核心 loop 管线，降低维护复杂度，为并行执行能力铺路（#2564、#2585）
+- **原生 Gemini Provider**：新增 Gemini 原生 provider，并分离 thought 消息与输出消息处理（#2475）
+- **工具链与会话稳定性提升**：新增 `/context` 指令与上下文用量指示；`/clear` 支持清理 Seahorse DB；定时任务改为独立会话执行（#2537、#2495、#2474）
+- **Web UI 体验改进**：工具页重构为标签化库/设置视图，补齐 Markdown 高亮，完善禁用态原因提示（#2539、#2529、#2523、#2430、#2526）
+- **搜索与网络鲁棒性增强**：新增可配置 Sogou 搜索后端，改进代理、错误分类与 fallback 处理（#2524、#2542、#2547、#2517）
+
+### 功能
+Core & Agent
+- **Loop 重构**：完成 Phase 1/2 的 loop 文件拆分与执行管线重排（#2564、#2585）
+- **LLM-as-Judge**：新增评测模式（#2484）
+- **并行执行能力演进**：推进 agent loop 对并行执行场景的支持（#2503）
+
+### Provider 与认证
+- **Gemini 原生协议支持**：原生 provider + thought/output 分离（#2475）
+- **OAuth 登录体验**：新增 `--no-browser` 选项，适配无 GUI 环境（#2549）
+- **认证兼容性改进**：不支持平台回退 token 认证；修复 Google Antigravity provider 规范化与凭据一致性（#2466、#2599）
+
+### Channel、工具与交互
+- **多实例 Channel 配置方向重构**：向多实例配置模型演进，修复嵌套 `channel_list` patch 保存并增强列表编辑（#2481、#2530、#2595）
+- **工具调用一致性**：修复跨轮复用 tool-call ID；保持工具调用摘要与 assistant 输出同步（#2528、#2449）
+- **禁用态提示完善**：补充 composer/tooltip 禁用原因提示并修复回归（#2523、#2430、#2526）
+
+### Bug 修复
+- **运行时恢复能力**：修复 reload 后 MCP/discovery 工具恢复；修复 image-input-unsupported 后恢复能力（#2489、#2525）
+- **Seahorse 搜索安全性**：修复 FTS5 MATCH 查询输入清洗问题（#2436）
+- **更新链路稳定性**：修复发布信息拉取瞬时失败重试；启动前错误日志补齐（#2511、#2414）
+- **配置与网络边界问题**：修复 `allowFrom` 包含空字符串问题；增强网络错误分类与 fallback（#2507、#2547）
+- **前端稳定性**：修复配置刷新重置搜索草稿；清理恢复会话转录并优化聊天 UI（#2536、#2605）
+- **工程质量修复**：修复 govet shadow 告警并调整不支持 OS 的隔离测试（#2613、#2434）
+
+### 构建与运维
+- **Android 发布链路**：新增 Android arm64 交叉编译，并将 Android bundle 发布纳入 GoReleaser（#2486、#2497）
+- **CI 流程更新**：切换到 `pnpm/action-setup` 并同步 README 安装步骤（#2512、#2552）
+- **依赖维护**：完成多项前后端依赖升级（React、TanStack、shadcn、sqlite、MCP SDK、router/lint 等）
+- **容器行为一致性**：自建镜像改为 root 运行，对齐发布镜像行为（#2435）
+
+### 文档
+- **文档结构重组**：按类型重组文档，补充 layout 指南与 session/routing 文档（#2567、#2571）
+- **协议文档更新**：更新 Gemini 原生协议文档与跨 provider JSON 转义说明（#2601、#2420）
+- **本地化与杂项修复**：新增韩文 README，修复 CONTRIBUTING 中 Conventional Commits 链接（#2418、#2494）
+
+### 完整变更
+- [GitHub v0.2.6...v0.2.7](https://github.com/sipeed/picoclaw/compare/v0.2.6...v0.2.7)
+
+---
+
+
 
 ## v0.2.6
 
@@ -73,7 +126,7 @@ PicoClaw 的所有重要更新记录。
 
 ### 完整更新日志
 - [GitHub v0.2.5...v0.2.6](https://github.com/sipeed/picoclaw/compare/v0.2.5...v0.2.6)
----
+
 
 ## v0.2.5
 


### PR DESCRIPTION
## Summary
This PR syncs the `v0.2.7` changelog content across locales to keep release notes aligned.

## Changes
- Added the `v0.2.7` changelog entry to English docs  
  - `docs/changelog.md`
- Added the `v0.2.7` changelog entry to pt-BR docs  
  - `i18n/pt-BR/docusaurus-plugin-content-docs/current/changelog.md`
- Fixed an inconsistency in zh-Hans `v0.2.7` full-changelog label vs compare link  
  - `i18n/zh-Hans/docusaurus-plugin-content-docs/current/changelog.md`

## Notes
- Documentation-only update; no runtime/code behavior changes.
- Unified full changelog compare link for `v0.2.7`:  
  `https://github.com/sipeed/picoclaw/compare/v0.2.6...v0.2.7`

## Validation
- Verified `v0.2.7` section exists in all three locale files.
- Verified compare link version is consistent.
