### PR TITLE
docs(chat-commands): add chat command reference (en/zh-Hans)

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -1,0 +1,138 @@
+---
+id: chat-commands
+title: Chat Command Reference
+sidebar_label: Chat Command Reference
+---
+
+PicoClaw supports interacting with the Agent through chat commands.
+> PicoClaw chat commands are defined centrally under `pkg/commands` and are handled by the Agent when a message starts with a command prefix.
+
+Supported prefixes:
+
+- `/` e.g. `/help`
+- `!` e.g. `!help`
+
+Telegram-style `/command@botname` is also normalized to the command name.
+
+## Command List
+
+### `/start`
+
+Starts or greets the bot. It replies with "Hello! I am PicoClaw 🦞".
+
+Usage: `/start`
+
+### `/help`
+
+Shows all available commands with short descriptions.
+
+Usage: `/help`
+
+### `/show [model|channel|agents|mcp <server>]`
+
+Shows current configuration or runtime information.
+
+**Subcommands:**
+
+| Subcommand | Description |
+|---|---|
+| `/show model` | Shows the current model and provider. |
+| `/show channel` | Shows the current channel. |
+| `/show agents` | Shows registered agents. |
+| `/show mcp <server>` | Shows active tools for a specified MCP server. |
+
+### `/list [models|channels|agents|skills|mcp]`
+
+Lists available options or configured resources.
+
+**Subcommands:**
+
+| Subcommand | Description |
+|---|---|
+| `/list models` | Shows the configured model and provider information. |
+| `/list channels` | Lists enabled channels. |
+| `/list agents` | Lists registered agents. |
+| `/list skills` | Lists installed skills and hints how to use `/use`. |
+| `/list mcp` | Lists configured MCP servers, enabled/deferred/connected status, and active tool count. |
+
+### `/use <skill> [message]`
+
+Forces use of a specific installed skill.
+
+**Usage patterns:**
+
+| Pattern | Behavior |
+|---|---|
+| `/use <skill> <message>` | Uses the specified skill for this message. |
+| `/use <skill>` | Arms the skill for the next normal message. |
+| `/use clear` or `/use off` | Clears the pending skill override. |
+
+### `/btw <question>`
+
+Asks a side question without changing the current session history. Useful for temporary or interrupting questions.
+
+Usage: `/btw <question>`
+
+Example: `/btw what is 2+2?`
+
+### `/switch model to <name>`
+
+Switches the model used by the current Agent.
+
+Usage: `/switch model to <name>`
+
+:::note
+`/switch channel` has been migrated to `/check channel`.
+:::
+
+### `/check channel <name>`
+
+Checks whether a channel is available and enabled.
+
+Usage: `/check channel <name>`
+
+### `/clear`
+
+Clears the chat history for the current session.
+
+Usage: `/clear`
+
+Reply: `Chat history cleared!`
+
+### `/context`
+
+Shows current session context and token usage, including message count, used tokens, total context window, compression threshold, compression progress, and remaining tokens.
+
+Usage: `/context`
+
+### `/subagents`
+
+Shows running subagents or the active task tree in the current session. If none are running, it reports that no active tasks exist.
+
+Usage: `/subagents`
+
+### `/reload`
+
+Reloads the configuration file.
+
+Usage: `/reload`
+
+Reply: `Config reload triggered!` or an error message.
+
+## Implementation Locations
+
+| Area | Path |
+|---|---|
+| Command definitions | `pkg/commands/builtin.go` and `pkg/commands/cmd_*.go` |
+| Command parsing | `pkg/commands/request.go` |
+| Command execution | `pkg/commands/executor.go` |
+| Agent integration | `pkg/agent/agent_command.go` |
+| Top-level CLI subcommands | `cmd/picoclaw/main.go` |
+
+## Additional: Top-level CLI Subcommands
+
+Besides chat slash commands, the `picoclaw` binary also provides Cobra CLI subcommands, including:
+
+`picoclaw onboard` · `picoclaw agent` · `picoclaw auth` · `picoclaw gateway` · `picoclaw status` · `picoclaw cron` · `picoclaw mcp` · `picoclaw migrate` · `picoclaw skills` · `picoclaw model` · `picoclaw update` · `picoclaw version`
+
+These CLI commands and chat commands are separate entry points: CLI commands run in the terminal, while chat commands are triggered through channel messages such as Telegram, Feishu, WeChat, etc.

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/chat-commands.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/chat-commands.md
@@ -1,0 +1,138 @@
+---
+id: chat-commands
+title: Referência de Comandos de Chat
+sidebar_label: Referência de Comandos de Chat
+---
+
+O PicoClaw suporta interação com o Agent por meio de comandos de chat.
+> Os comandos de chat do PicoClaw são definidos centralmente em `pkg/commands` e são processados pelo Agent quando uma mensagem começa com um prefixo de comando.
+
+Prefixos suportados:
+
+- `/` ex. `/help`
+- `!` ex. `!help`
+
+O estilo Telegram `/command@botname` também é normalizado para o nome do comando.
+
+## Lista de Comandos
+
+### `/start`
+
+Inicia ou cumprimenta o bot. Responde com "Hello! I am PicoClaw 🦞".
+
+Uso: `/start`
+
+### `/help`
+
+Mostra todos os comandos disponíveis com descrições curtas.
+
+Uso: `/help`
+
+### `/show [model|channel|agents|mcp <server>]`
+
+Mostra a configuração atual ou informações de execução.
+
+**Subcomandos:**
+
+| Subcomando | Descrição |
+|---|---|
+| `/show model` | Mostra o modelo e o provider atuais. |
+| `/show channel` | Mostra o canal atual. |
+| `/show agents` | Mostra os agents registrados. |
+| `/show mcp <server>` | Mostra as ferramentas ativas de um servidor MCP específico. |
+
+### `/list [models|channels|agents|skills|mcp]`
+
+Lista opções disponíveis ou recursos configurados.
+
+**Subcomandos:**
+
+| Subcomando | Descrição |
+|---|---|
+| `/list models` | Mostra as informações do modelo e provider configurados. |
+| `/list channels` | Lista os canais habilitados. |
+| `/list agents` | Lista os agents registrados. |
+| `/list skills` | Lista as skills instaladas e indica como usar `/use`. |
+| `/list mcp` | Lista os servidores MCP configurados, status habilitado/adiado/conectado e quantidade de ferramentas ativas. |
+
+### `/use <skill> [message]`
+
+Força o uso de uma skill instalada específica.
+
+**Padrões de uso:**
+
+| Padrão | Comportamento |
+|---|---|
+| `/use <skill> <message>` | Usa a skill especificada para esta mensagem. |
+| `/use <skill>` | Prepara a skill para a próxima mensagem normal. |
+| `/use clear` ou `/use off` | Cancela o override de skill pendente. |
+
+### `/btw <question>`
+
+Faz uma pergunta lateral sem alterar o histórico da sessão atual. Útil para consultas temporárias ou perguntas de interrupção.
+
+Uso: `/btw <question>`
+
+Exemplo: `/btw what is 2+2?`
+
+### `/switch model to <name>`
+
+Alterna o modelo usado pelo Agent atual.
+
+Uso: `/switch model to <name>`
+
+:::note
+`/switch channel` foi migrado para `/check channel`.
+:::
+
+### `/check channel <name>`
+
+Verifica se um canal está disponível e habilitado.
+
+Uso: `/check channel <name>`
+
+### `/clear`
+
+Limpa o histórico de chat da sessão atual.
+
+Uso: `/clear`
+
+Resposta: `Chat history cleared!`
+
+### `/context`
+
+Mostra o contexto e o uso de tokens da sessão atual, incluindo contagem de mensagens, tokens usados, janela total de contexto, limiar de compressão, progresso da compressão e tokens restantes.
+
+Uso: `/context`
+
+### `/subagents`
+
+Mostra os subagents em execução ou a árvore de tarefas ativas na sessão atual. Se não houver tarefas em execução, informa que nenhuma tarefa ativa existe.
+
+Uso: `/subagents`
+
+### `/reload`
+
+Recarrega o arquivo de configuração.
+
+Uso: `/reload`
+
+Resposta: `Config reload triggered!` ou uma mensagem de erro.
+
+## Locais de Implementação
+
+| Área | Caminho |
+|---|---|
+| Definições de comandos | `pkg/commands/builtin.go` e `pkg/commands/cmd_*.go` |
+| Análise de comandos | `pkg/commands/request.go` |
+| Execução de comandos | `pkg/commands/executor.go` |
+| Integração com Agent | `pkg/agent/agent_command.go` |
+| Subcomandos CLI de nível superior | `cmd/picoclaw/main.go` |
+
+## Adicional: Subcomandos CLI de Nível Superior
+
+Além dos comandos slash de chat, o binário `picoclaw` também oferece subcomandos Cobra CLI, incluindo:
+
+`picoclaw onboard` · `picoclaw agent` · `picoclaw auth` · `picoclaw gateway` · `picoclaw status` · `picoclaw cron` · `picoclaw mcp` · `picoclaw migrate` · `picoclaw skills` · `picoclaw model` · `picoclaw update` · `picoclaw version`
+
+Esses comandos CLI e comandos de chat são pontos de entrada separados: comandos CLI são executados no terminal, enquanto comandos de chat são acionados por mensagens de canais como Telegram, Feishu, WeChat, etc.

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/chat-commands.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/chat-commands.md
@@ -1,0 +1,138 @@
+---
+id: chat-commands
+title: 聊天命令参考
+sidebar_label: 聊天命令参考
+---
+
+PicoClaw 支持通过聊天命令与 Agent 交互。
+> PicoClaw 的聊天命令由 `pkg/commands` 统一定义，并由 Agent 在收到以命令前缀开头的消息时处理。
+
+支持的命令前缀:
+
+- `/` 例如 `/help`
+- `!` 例如 `!help`
+
+Telegram 风格的 `/command@botname` 也会被解析为对应命令。
+
+## 命令列表
+
+### `/start`
+
+启动/问候命令，返回 "Hello! I am PicoClaw 🦞"。
+
+用法: `/start`
+
+### `/help`
+
+显示所有可用命令及简要说明。
+
+用法: `/help`
+
+### `/show [model|channel|agents|mcp <server>]`
+
+显示当前配置或运行状态。
+
+**子命令:**
+
+| 子命令 | 说明 |
+|---|---|
+| `/show model` | 显示当前模型与 provider。 |
+| `/show channel` | 显示当前消息来源 channel。 |
+| `/show agents` | 显示已注册 Agent。 |
+| `/show mcp <server>` | 显示指定 MCP server 当前可用工具。 |
+
+### `/list [models|channels|agents|skills|mcp]`
+
+列出可用选项或已配置资源。
+
+**子命令:**
+
+| 子命令 | 说明 |
+|---|---|
+| `/list models` | 显示当前配置模型与 provider 信息。 |
+| `/list channels` | 列出已启用 channel。 |
+| `/list agents` | 列出已注册 Agent。 |
+| `/list skills` | 列出已安装 skills，并提示可用 `/use` 调用。 |
+| `/list mcp` | 列出已配置 MCP servers、启用状态、延迟加载状态、连接状态和 active tools 数量。 |
+
+### `/use <skill> [message]`
+
+强制指定某个已安装 skill。
+
+**用法模式:**
+
+| 模式 | 行为 |
+|---|---|
+| `/use <skill> <message>` | 对当前这条 message 使用指定 skill。 |
+| `/use <skill>` | 将该 skill 预置给下一条普通消息。 |
+| `/use clear` 或 `/use off` | 取消下一条消息的 skill override。 |
+
+### `/btw <question>`
+
+提出一个"旁路问题"，不会改变当前会话历史。适合临时查询、插入式问题。
+
+用法: `/btw <question>`
+
+示例: `/btw what is 2+2?`
+
+### `/switch model to <name>`
+
+切换当前 Agent 使用的模型。
+
+用法: `/switch model to <name>`
+
+:::note
+`/switch channel` 已迁移到 `/check channel`。
+:::
+
+### `/check channel <name>`
+
+检查某个 channel 是否可用且已启用。
+
+用法: `/check channel <name>`
+
+### `/clear`
+
+清空当前 session 的聊天历史。
+
+用法: `/clear`
+
+返回: `Chat history cleared!`
+
+### `/context`
+
+显示当前 session 的上下文和 token 使用情况，包括消息数、已用 token、总窗口、压缩阈值、压缩进度和剩余 token。
+
+用法: `/context`
+
+### `/subagents`
+
+显示当前 session 中正在运行的 subagents / task tree。如果没有活动任务，会提示没有正在运行的任务。
+
+用法: `/subagents`
+
+### `/reload`
+
+重新加载配置文件。
+
+用法: `/reload`
+
+返回: `Config reload triggered!` 或错误信息。
+
+## 实现位置
+
+| 区域 | 路径 |
+|---|---|
+| 命令定义 | `pkg/commands/builtin.go` 和 `pkg/commands/cmd_*.go` |
+| 命令解析 | `pkg/commands/request.go` |
+| 命令执行 | `pkg/commands/executor.go` |
+| Agent 接入 | `pkg/agent/agent_command.go` |
+| 顶层 CLI 子命令 | `cmd/picoclaw/main.go` |
+
+## 补充：CLI 顶层子命令
+
+除了聊天里的 slash 命令，`picoclaw` 二进制还提供 Cobra CLI 子命令，包括：
+
+`picoclaw onboard` · `picoclaw agent` · `picoclaw auth` · `picoclaw gateway` · `picoclaw status` · `picoclaw cron` · `picoclaw mcp` · `picoclaw migrate` · `picoclaw skills` · `picoclaw model` · `picoclaw update` · `picoclaw version`
+
+这些 CLI 命令与聊天命令是两套入口：CLI 通过终端执行，聊天命令通过 Telegram/Feishu/微信等 channel 消息触发。

--- a/sidebars.js
+++ b/sidebars.js
@@ -12,6 +12,11 @@ const sidebars = {
       label: 'Getting Started',
     },
     {
+      type: 'doc',
+      id: 'chat-commands',
+      label: 'Chat Commands',
+    },
+    {
       type: 'category',
       label: 'Installation',
       collapsible: true,


### PR DESCRIPTION
## Summary
- Add bilingual (English/Chinese) documentation for all PicoClaw chat commands
- Covers `/start`, `/help`, `/show`, `/list`, `/use`, `/btw`, `/switch`, `/check`, `/clear`, `/context`, `/subagents`, `/reload`
- Includes implementation location references and CLI subcommand overview
- Add sidebar entry for quick navigation

