### PR TITLE
feat: add Codex-powered upstream doc sync workflows

### DIFF
--- a/.github/prompts/review-sync.md
+++ b/.github/prompts/review-sync.md
@@ -1,0 +1,67 @@
+You are reviewing a documentation sync PR for the PicoClaw project.
+Another Codex agent just synced the docs with upstream source changes. Your job is to catch mistakes before the PR is created.
+
+## Diff Summary
+
+```
+${DIFF_STAT}
+```
+
+## Diff Content (truncated to 3000 chars)
+
+```diff
+${DIFF_CONTENT}
+```
+
+## Review Checklist
+
+Go through each item carefully:
+
+### 1. No unwanted files
+- `picoclaw-upstream/`, `.codex`, `node_modules/`, `.pr-summary.md` must NOT appear in `git diff --stat HEAD`.
+- If found, revert with `git checkout -- <path>` or `rm -rf <path>`.
+
+### 2. No regressions
+- `docusaurus.config.js` should NOT be modified unless there's a genuine reason (e.g., new locale config).
+- `package.json` / `package-lock.json` should NOT be modified.
+
+### 3. No duplicate pages
+- Do not create a new page (e.g., `wecom.md`) when split pages already exist (e.g., `wecom-aibot.md`, `wecom-app.md`, `wecom-bot.md`).
+- Run `ls docs/channels/` and `ls docs/providers/` to check existing structure before adding files.
+
+### 4. Content accuracy
+- Spot-check 2-3 changed doc pages against their upstream source files in `picoclaw-upstream/`.
+- No hallucinated features, config options, or API endpoints.
+- Code examples must match the actual source code.
+
+### 5. Trilingual completeness
+- Every changed English doc in `docs/` must have corresponding updates in:
+  - `i18n/zh-Hans/docusaurus-plugin-content-docs/current/`
+  - `i18n/pt-BR/docusaurus-plugin-content-docs/current/`
+- Check with: `git diff --stat HEAD -- docs/ | sed 's|docs/||'` and verify each path exists in both i18n dirs.
+
+### 6. `.doc-source.json` integrity
+- `source_commit` must be a full 40-character commit hash, not a short hash.
+- All new pages must have source file mappings.
+- `generated_at` must be a valid ISO 8601 timestamp.
+
+### 7. MDX safety
+- No unescaped `<`, `{`, `}` in prose text (outside code blocks).
+- Frontmatter must be valid YAML (no tabs, proper quoting).
+
+### 8. Sidebar consistency
+- If new pages were created, they must be added to `sidebars.js`.
+- Run `node -e "require('./sidebars.js')"` to verify sidebar syntax.
+
+### 9. Build verification
+- Run `npm run build` to verify the build passes.
+- If it fails, fix ALL errors before finishing.
+
+## Instructions
+
+1. Run through the checklist above.
+2. Fix any issues you find — do not just report them.
+3. After fixing, run `npm run build` again to confirm.
+4. Output a brief summary of what you checked and what you fixed (if anything).
+
+${EXTRA_INSTRUCTIONS}

--- a/.github/prompts/sync-docs.md
+++ b/.github/prompts/sync-docs.md
@@ -1,0 +1,126 @@
+You are a documentation sync agent for the PicoClaw project.
+Your job is to sync the documentation site (Docusaurus 3.x, locales: en + zh-Hans + pt-BR) with upstream source code changes.
+
+## Repository Layout
+
+- **Docs repo (this repo)**: the current working directory
+  - Framework: Docusaurus 3.x
+  - URL: `https://docs.picoclaw.io`, baseUrl: `/`
+  - Locales: en (`docs/`), zh-Hans (`i18n/zh-Hans/docusaurus-plugin-content-docs/current/`), pt-BR (`i18n/pt-BR/docusaurus-plugin-content-docs/current/`)
+  - Sync tracking: `.doc-source.json` at repo root
+- **Source repo**: `picoclaw-upstream/` directory (checked out at repo root)
+  - This is the latest `sipeed/picoclaw` main branch
+
+## Upstream Change Summary
+
+Last synced commit: `${OLD_COMMIT}`
+Target: `${TARGET_LABEL}`
+Target commit: `${NEW_COMMIT}`
+
+### Commit log since last sync
+```
+${COMMIT_LOG}
+```
+
+### Changed files
+```
+${CHANGED_FILES}
+```
+
+### Diff stat
+```
+${DIFF_STAT}
+```
+
+## Your Task
+
+### Phase 1: Diff Analysis
+
+1. Read `.doc-source.json` to understand the doc-to-source mapping.
+2. Cross-reference the changed files above against `.doc-source.json` mappings to identify which doc pages need updating.
+3. Also check for:
+   - New channel directories in `picoclaw-upstream/pkg/channels/` not yet in docs
+   - New provider files in `picoclaw-upstream/pkg/providers/` not yet documented
+   - New packages in `picoclaw-upstream/pkg/` that may need new doc pages
+   - New/changed docs in `picoclaw-upstream/docs/` directory
+   - Config changes in `picoclaw-upstream/config/config.example.json` and `picoclaw-upstream/pkg/config/`
+
+### Phase 2: Update Documentation
+
+For each page needing updates:
+1. Read the current doc page (English version in `docs/`)
+2. Read all its mapped source files from `picoclaw-upstream/`
+3. Run `git -C picoclaw-upstream diff ${OLD_COMMIT}..HEAD -- <source_file>` to see what changed
+4. Update the doc page:
+   - Preserve frontmatter (sidebar_position, title, etc.)
+   - Preserve writing style and structure
+   - Add/modify sections for new options, features, or behavior changes
+   - Update code examples to match current source
+5. Update translations:
+   - Chinese: `i18n/zh-Hans/docusaurus-plugin-content-docs/current/<same_path>`
+   - Portuguese: `i18n/pt-BR/docusaurus-plugin-content-docs/current/<same_path>`
+
+For new channels, providers, or features:
+1. Use an existing similar page as the template
+2. Read the upstream source code thoroughly
+3. Create English page in `docs/`
+4. Create translations:
+   - Chinese: `i18n/zh-Hans/docusaurus-plugin-content-docs/current/`
+   - Portuguese: `i18n/pt-BR/docusaurus-plugin-content-docs/current/`
+5. Add to `sidebars.js` in the appropriate category
+6. Add source mapping to `.doc-source.json`
+
+### Phase 3: Gap Analysis
+
+1. **Config reference**: Compare `picoclaw-upstream/config/config.example.json` and `picoclaw-upstream/pkg/config/config.go` against `docs/configuration/config-reference.md` — document any missing config options.
+2. **Channels**: List all dirs under `picoclaw-upstream/pkg/channels/` — each should have a doc page under `docs/channels/`.
+3. **Providers**: Check `picoclaw-upstream/pkg/providers/` for undocumented providers.
+4. **Sidebar**: Compare `sidebars.js` against actual files in `docs/` — ensure every page is reachable.
+5. Fix any gaps found (all three locales: en, zh-Hans, pt-BR).
+
+### Phase 4: Finalize
+
+1. Update `.doc-source.json`:
+   - Set `source_commit` to `${NEW_COMMIT}`
+   - Set `generated_at` to current ISO 8601 timestamp
+   - Add/update any new doc-to-source mappings
+2. Run `npm ci && npm run build` to verify the build passes.
+   - If build fails, fix all errors (broken MDX syntax, missing frontmatter, dead links, sidebar issues).
+3. Write a PR summary file at `.pr-summary.md` (this will be used by the workflow to create the PR). Format:
+   ```
+   title: <concise PR title, e.g. "docs: add WeChat Work channel, update config reference">
+   ---
+   <PR body in markdown — summarize what was added/changed/fixed, organized by section>
+   ```
+   The title line must be the first line. Everything after `---` is the body.
+
+### Phase 5: Self-Review via Sub-Agent
+
+After completing all changes, spawn a sub-agent to independently review your work. The sub-agent should:
+
+1. Run `git diff --stat HEAD` to see all changed files
+2. Check each change against this checklist:
+   - **No unwanted files**: `picoclaw-upstream/`, `.codex`, `node_modules/` must NOT be staged or modified. Revert with `git checkout -- <file>` if found.
+   - **No regressions**: `docusaurus.config.js` should NOT be modified unless there's a genuine new sidebar entry.
+   - **No duplicate pages**: Do not create a new page (e.g. `wecom.md`) when split pages already exist (e.g. `wecom-aibot.md`, `wecom-app.md`, `wecom-bot.md`). Check existing file structure first.
+   - **Content accuracy**: Spot-check 2-3 changed docs against their `picoclaw-upstream/` source files. No hallucinated features or config options.
+   - **Trilingual completeness**: Every changed English doc must have corresponding zh-Hans and pt-BR updates.
+   - **`.doc-source.json` integrity**: `source_commit` must be a full commit hash, not a short hash. All new pages must have source mappings.
+   - **MDX safety**: No unescaped `<`, `{`, `}` in prose text.
+3. Run `npm run build` to verify the build passes.
+4. Fix any issues found and summarize what was corrected.
+
+This review step is critical — do not skip it.
+
+## Important Rules
+
+- **Read before write**: Always read upstream source files before writing documentation. Never guess at behavior.
+- **Trilingual**: Every doc change MUST include all three locales: English, Chinese (zh-Hans), and Portuguese (pt-BR).
+- **Preserve style**: Match the existing writing style, tone, and structure.
+- **Accurate mappings**: Keep `.doc-source.json` accurate.
+- **Build must pass**: Do not finish if `npm run build` fails.
+- **Template from peers**: When creating new channel/provider docs, copy structure from an existing similar page.
+- **Config docs are tables**: The config reference uses markdown tables — maintain that format.
+- **OpenAI-compat providers**: Providers using OpenAI-compatible interface go in `providers/index.md`, not separate pages (unless they have unique setup).
+
+${EXTRA_INSTRUCTIONS}

--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UPSTREAM_DIR="${1:?Usage: detect-changes.sh <upstream-dir>}"
+DOC_SOURCE="${2:-.doc-source.json}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
+OLD_COMMIT_RAW=$(jq -r '.source_commit' "$DOC_SOURCE")
+NEW_COMMIT=$(git -C "$UPSTREAM_DIR" rev-parse --short HEAD)
+NEW_COMMIT_FULL=$(git -C "$UPSTREAM_DIR" rev-parse HEAD)
+
+if ! OLD_COMMIT=$(git -C "$UPSTREAM_DIR" rev-parse "$OLD_COMMIT_RAW" 2>/dev/null); then
+  echo "::warning::Cannot resolve source_commit '$OLD_COMMIT_RAW' in upstream repo. Treating as full diff."
+  OLD_COMMIT=""
+fi
+
+echo "old_commit=${OLD_COMMIT:-$OLD_COMMIT_RAW}" >> "$GITHUB_OUTPUT"
+echo "new_commit=$NEW_COMMIT" >> "$GITHUB_OUTPUT"
+echo "new_commit_full=$NEW_COMMIT_FULL" >> "$GITHUB_OUTPUT"
+
+if [ -n "$OLD_COMMIT" ] && git -C "$UPSTREAM_DIR" merge-base --is-ancestor "$NEW_COMMIT_FULL" "$OLD_COMMIT" 2>/dev/null; then
+  echo "has_changes=false" >> "$GITHUB_OUTPUT"
+  echo "No new upstream changes since $OLD_COMMIT"
+else
+  echo "has_changes=true" >> "$GITHUB_OUTPUT"
+  if [ -n "$OLD_COMMIT" ]; then
+    COMMIT_LOG=$(git -C "$UPSTREAM_DIR" log --oneline -50 "$OLD_COMMIT"..HEAD)
+    CHANGED_FILES=$(git -C "$UPSTREAM_DIR" diff --name-only "$OLD_COMMIT"..HEAD)
+    DIFF_STAT=$(git -C "$UPSTREAM_DIR" diff --stat "$OLD_COMMIT"..HEAD)
+  else
+    COMMIT_LOG=$(git -C "$UPSTREAM_DIR" log --oneline -50)
+    CHANGED_FILES="(full repo — old commit not found)"
+    DIFF_STAT="(full repo — old commit not found)"
+  fi
+
+  {
+    echo "commit_log<<ENDOFLOG"
+    echo "$COMMIT_LOG"
+    echo "ENDOFLOG"
+  } >> "$GITHUB_OUTPUT"
+
+  {
+    echo "changed_files<<ENDOFFILES"
+    echo "$CHANGED_FILES"
+    echo "ENDOFFILES"
+  } >> "$GITHUB_OUTPUT"
+
+  {
+    echo "diff_stat<<ENDOFSTAT"
+    echo "$DIFF_STAT"
+    echo "ENDOFSTAT"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,235 @@
+name: ChatOps
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  # /fix <instructions> — Run Codex to fix issues on a PR branch
+  fix:
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/fix') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: fix-pr-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Get PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          PR_JSON=$(gh api "$PR_URL")
+          echo "branch=$(echo "$PR_JSON" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
+          echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+
+      - name: React to comment
+        id: react
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          REACTION_ID=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content='rocket' --jq '.id')
+          echo "reaction_id=$REACTION_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Extract fix instructions
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          INSTRUCTIONS="${COMMENT_BODY#/fix}"
+          INSTRUCTIONS="${INSTRUCTIONS#"${INSTRUCTIONS%%[![:space:]]*}"}"
+          if [ -z "$INSTRUCTIONS" ]; then
+            echo "::error::Usage: /fix <instructions>"
+            exit 1
+          fi
+          {
+            echo "instructions<<ENDINST"
+            echo "$INSTRUCTIONS"
+            echo "ENDINST"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout picoclaw source repo
+        uses: actions/checkout@v4
+        with:
+          repository: sipeed/picoclaw
+          path: picoclaw-upstream
+          fetch-depth: 0
+
+      - name: Detach picoclaw-upstream from git
+        run: rm -rf picoclaw-upstream/.git
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Capture current build errors
+        id: build
+        run: |
+          npm ci
+          BUILD_OUTPUT=$(npm run build 2>&1) || true
+          {
+            echo "errors<<ENDBUILD"
+            echo "$BUILD_OUTPUT" | grep -i -A2 "error\|warning\|fail" | tail -50
+            echo "ENDBUILD"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Codex to fix
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL }}
+          model: gpt-5.5
+          sandbox: danger-full-access
+          safety-strategy: drop-sudo
+          prompt: |
+            You are fixing an existing documentation PR for the PicoClaw project.
+
+            ## Context
+
+            - **Docs repo**: the current working directory (Docusaurus 3.x)
+            - **Source repo**: `picoclaw-upstream/` directory (sipeed/picoclaw latest main)
+            - Locales: en (`docs/`), zh-Hans (`i18n/zh-Hans/...`), pt-BR (`i18n/pt-BR/...`)
+
+            ## Fix Instructions
+
+            ${{ steps.parse.outputs.instructions }}
+
+            ## Current Build Errors (if any)
+
+            ```
+            ${{ steps.build.outputs.errors }}
+            ```
+
+            ## Rules
+
+            - Only modify files related to the fix. Do not touch unrelated files.
+            - Do NOT modify or create files in `picoclaw-upstream/`, `.codex`, or `docusaurus.config.js` unless explicitly asked.
+            - If fixing build errors, run `npm run build` after changes to verify.
+            - Keep all three locales in sync (en, zh-Hans, pt-BR).
+            - Preserve existing file structure — do not create files that duplicate existing ones.
+            - If the PR title or description should be updated, write a file `.pr-update.md` with format:
+              ```
+              title: <new PR title>
+              ---
+              <new PR body in markdown>
+              ```
+              The title line is required. The body after `---` is optional (omit to keep existing body).
+
+      - name: Clean up artifacts
+        run: rm -rf picoclaw-upstream .codex
+
+      - name: Verify build
+        run: npm run build
+
+      - name: Update PR metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          if [ ! -f .pr-update.md ]; then exit 0; fi
+          PR_TITLE=$(head -1 .pr-update.md | sed 's/^title: *//')
+          if [ -n "$PR_TITLE" ]; then
+            gh pr edit "$PR_NUMBER" --title "$PR_TITLE"
+          fi
+          if grep -q '^---$' .pr-update.md; then
+            PR_BODY=$(sed '1,/^---$/d' .pr-update.md)
+            if [ -n "$PR_BODY" ]; then
+              gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+            fi
+          fi
+          rm -f .pr-update.md
+
+      - name: Commit and push
+        id: push
+        env:
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Stage any uncommitted changes Codex left in the working tree
+          git add -A
+          git reset -- picoclaw-upstream .codex .pr-update.md 2>/dev/null || true
+          if ! git diff --cached --quiet; then
+            git commit -m "fix: apply requested changes via /fix command
+
+          Co-Authored-By: Codex <noreply@openai.com>"
+          fi
+
+          # Push if there are any commits ahead of remote (Codex may have committed directly)
+          if [ -n "$(git log "origin/$BRANCH..HEAD" --oneline 2>/dev/null)" ]; then
+            git push origin HEAD:"$BRANCH" --force-with-lease
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update reaction and comment result
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION_ID: ${{ steps.react.outputs.reaction_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JOB_STATUS: ${{ job.status }}
+          PUSHED: ${{ steps.push.outputs.pushed }}
+        run: |
+          # Remove rocket reaction
+          if [ -n "$REACTION_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions/$REACTION_ID" \
+              -X DELETE --silent 2>/dev/null || true
+          fi
+          # Add result reaction
+          if [ "$JOB_STATUS" = "success" ] && [ "$PUSHED" = "true" ]; then
+            EMOJI="+1"
+            BODY="Fix applied successfully. Please review the new changes."
+          elif [ "$JOB_STATUS" = "success" ]; then
+            EMOJI="confused"
+            BODY="Codex ran but produced no changes. Check the [workflow run]($RUN_URL) for details."
+          else
+            EMOJI="-1"
+            BODY="Fix attempt failed. Check the [workflow run]($RUN_URL) for details."
+          fi
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content="$EMOJI" --silent 2>/dev/null || true
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+
+  # Add more commands below as new jobs, e.g.:
+  #
+  # retry:
+  #   if: >
+  #     github.event.issue.pull_request &&
+  #     github.event.comment.body == '/retry' &&
+  #     contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+  #   ...
+  #
+  # review:
+  #   if: >
+  #     github.event.issue.pull_request &&
+  #     startsWith(github.event.comment.body, '/review') &&
+  #     contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+  #   ...

--- a/.github/workflows/fix-on-review.yml
+++ b/.github/workflows/fix-on-review.yml
@@ -1,0 +1,213 @@
+name: Fix PR on review request changes
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix:
+    if: >
+      github.event.review.state == 'changes_requested' &&
+      contains(github.event.pull_request.labels.*.name, 'automated')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: fix-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Collect review comments
+        id: review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_ID: ${{ github.event.review.id }}
+        run: |
+          REVIEW_BODY=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.body')
+
+          INLINE_COMMENTS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/comments" \
+            --jq '.[] | "- `\(.path)`\(if .line then " L\(.line)" else "" end): \(.body)"')
+
+          {
+            echo "comments<<ENDCOMMENTS"
+            if [ -n "$REVIEW_BODY" ]; then
+              echo "## Review Summary"
+              echo "$REVIEW_BODY"
+              echo ""
+            fi
+            if [ -n "$INLINE_COMMENTS" ]; then
+              echo "## Inline Comments"
+              echo "$INLINE_COMMENTS"
+            fi
+            echo "ENDCOMMENTS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: React to review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "Received review feedback. Running Codex to apply fixes..."
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout picoclaw source repo
+        uses: actions/checkout@v4
+        with:
+          repository: sipeed/picoclaw
+          path: picoclaw-upstream
+          fetch-depth: 0
+
+      - name: Detach picoclaw-upstream from git
+        run: rm -rf picoclaw-upstream/.git
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Capture current build errors
+        id: build
+        run: |
+          npm ci
+          BUILD_OUTPUT=$(npm run build 2>&1) || true
+          {
+            echo "errors<<ENDBUILD"
+            echo "$BUILD_OUTPUT" | grep -i -A2 "error\|warning\|fail" | tail -50
+            echo "ENDBUILD"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Codex to fix
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL }}
+          model: gpt-5.5
+          sandbox: danger-full-access
+          safety-strategy: drop-sudo
+          prompt: |
+            You are fixing an existing documentation PR for the PicoClaw project based on reviewer feedback.
+
+            ## Context
+
+            - **Docs repo**: the current working directory (Docusaurus 3.x)
+            - **Source repo**: `picoclaw-upstream/` directory (sipeed/picoclaw latest main)
+            - Locales: en (`docs/`), zh-Hans (`i18n/zh-Hans/...`), pt-BR (`i18n/pt-BR/...`)
+
+            ## Reviewer Feedback
+
+            ${{ steps.review.outputs.comments }}
+
+            ## Current Build Errors (if any)
+
+            ```
+            ${{ steps.build.outputs.errors }}
+            ```
+
+            ## Rules
+
+            - Address ALL reviewer comments. For inline comments, fix the specific file and line mentioned.
+            - Only modify files related to the review feedback. Do not touch unrelated files.
+            - Do NOT modify or create files in `picoclaw-upstream/`, `.codex`, or `docusaurus.config.js` unless explicitly asked.
+            - If fixing build errors, run `npm run build` after changes to verify.
+            - Keep all three locales in sync (en, zh-Hans, pt-BR).
+            - Preserve existing file structure — do not create files that duplicate existing ones.
+            - If the PR title or description should be updated, write a file `.pr-update.md` with format:
+              ```
+              title: <new PR title>
+              ---
+              <new PR body in markdown>
+              ```
+              The title line is required. The body after `---` is optional (omit to keep existing body).
+
+      - name: Clean up artifacts
+        run: rm -rf picoclaw-upstream .codex
+
+      - name: Verify build
+        run: npm run build
+
+      - name: Update PR metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ ! -f .pr-update.md ]; then exit 0; fi
+          PR_TITLE=$(head -1 .pr-update.md | sed 's/^title: *//')
+          if [ -n "$PR_TITLE" ]; then
+            gh pr edit "$PR_NUMBER" --title "$PR_TITLE"
+          fi
+          if grep -q '^---$' .pr-update.md; then
+            PR_BODY=$(sed '1,/^---$/d' .pr-update.md)
+            if [ -n "$PR_BODY" ]; then
+              gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+            fi
+          fi
+          rm -f .pr-update.md
+
+      - name: Commit and push
+        id: push
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Stage any uncommitted changes Codex left in the working tree
+          git add -A
+          git reset -- picoclaw-upstream .codex .pr-update.md 2>/dev/null || true
+          if ! git diff --cached --quiet; then
+            git commit -m "fix: address review feedback
+
+          Co-Authored-By: Codex <noreply@openai.com>"
+          fi
+
+          # Push if there are any commits ahead of remote (Codex may have committed directly)
+          if [ -n "$(git log "origin/$BRANCH..HEAD" --oneline 2>/dev/null)" ]; then
+            git push origin HEAD:"$BRANCH" --force-with-lease
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-request review
+        if: success() && steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEWER: ${{ github.event.review.user.login }}
+        run: |
+          gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+            -f "reviewers[]=$REVIEWER" --silent || true
+
+      - name: Comment result
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEWER: ${{ github.event.review.user.login }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JOB_STATUS: ${{ job.status }}
+          PUSHED: ${{ steps.push.outputs.pushed }}
+        run: |
+          if [ "$JOB_STATUS" != "success" ]; then
+            BODY="Failed to address review feedback. Check the [workflow run]($RUN_URL) for details."
+          elif [ "$PUSHED" = "true" ]; then
+            BODY="Review feedback addressed. Re-requested review from @$REVIEWER."
+          else
+            BODY="Codex ran but produced no changes. Check the [workflow run]($RUN_URL) for details."
+          fi
+          gh pr comment "$PR_NUMBER" --body "$BODY"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,234 @@
+name: Sync upstream picoclaw docs
+
+on:
+  # Uncomment to enable scheduled sync:
+  # schedule:
+  #   - cron: '0 8 * * 1-5'  # weekdays at 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Upstream tag to sync to (e.g. v0.3.0). Leave empty for latest HEAD."
+        required: false
+        default: ""
+      model:
+        description: "OpenAI model to use"
+        required: false
+        default: "gpt-5.5"
+      extra_instructions:
+        description: "Additional instructions for the sync (optional)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-upstream
+  cancel-in-progress: false
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate tag exists upstream
+        if: github.event.inputs.tag != ''
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if ! git ls-remote --tags https://github.com/sipeed/picoclaw.git "refs/tags/$TAG" | grep -q .; then
+            echo "::error::Tag '$TAG' not found in sipeed/picoclaw"
+            exit 1
+          fi
+
+      - name: Checkout picoclaw source repo
+        uses: actions/checkout@v4
+        with:
+          repository: sipeed/picoclaw
+          path: picoclaw-upstream
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || '' }}
+
+      - name: Resolve target ref
+        id: ref
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ -n "$TAG" ]; then
+            echo "label=$TAG" >> "$GITHUB_OUTPUT"
+            echo "Syncing to tag: $TAG"
+          else
+            SHORT=$(git -C picoclaw-upstream rev-parse --short HEAD)
+            echo "label=$SHORT" >> "$GITHUB_OUTPUT"
+            echo "Syncing to HEAD: $SHORT"
+          fi
+
+      - name: Detect upstream changes
+        id: detect
+        run: .github/scripts/detect-changes.sh picoclaw-upstream .doc-source.json
+
+      - name: Skip if no changes
+        if: steps.detect.outputs.has_changes == 'false'
+        run: echo "No upstream changes detected. Skipping sync."
+
+      - name: Detach picoclaw-upstream from git
+        if: steps.detect.outputs.has_changes == 'true'
+        run: rm -rf picoclaw-upstream/.git
+
+      - name: Setup Node.js
+        if: steps.detect.outputs.has_changes == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Prepare Codex prompt
+        if: steps.detect.outputs.has_changes == 'true'
+        id: prompt
+        env:
+          OLD_COMMIT: ${{ steps.detect.outputs.old_commit }}
+          NEW_COMMIT: ${{ steps.detect.outputs.new_commit_full }}
+          TARGET_LABEL: ${{ steps.ref.outputs.label }}
+          EXTRA_INSTRUCTIONS: ${{ github.event.inputs.extra_instructions }}
+          COMMIT_LOG: ${{ steps.detect.outputs.commit_log }}
+          CHANGED_FILES: ${{ steps.detect.outputs.changed_files }}
+          DIFF_STAT: ${{ steps.detect.outputs.diff_stat }}
+        run: |
+          envsubst '$OLD_COMMIT $NEW_COMMIT $TARGET_LABEL $EXTRA_INSTRUCTIONS $COMMIT_LOG $CHANGED_FILES $DIFF_STAT' \
+            < .github/prompts/sync-docs.md > /tmp/prompt.md
+          {
+            echo "value<<ENDOFPROMPT"
+            cat /tmp/prompt.md
+            echo "ENDOFPROMPT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Codex to sync docs
+        if: steps.detect.outputs.has_changes == 'true'
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL }}
+          model: ${{ github.event.inputs.model || 'gpt-5.5' }}
+          sandbox: danger-full-access
+          safety-strategy: drop-sudo
+          prompt: ${{ steps.prompt.outputs.value }}
+
+      - name: Capture sync diff for review
+        if: steps.detect.outputs.has_changes == 'true'
+        id: sync_diff
+        run: |
+          DIFF_STAT=$(git diff --stat HEAD)
+          DIFF_CONTENT=$(git diff HEAD -- ':!picoclaw-upstream' ':!.codex' | head -3000)
+          {
+            echo "diff_stat<<ENDSYNCSTAT"
+            echo "$DIFF_STAT"
+            echo "ENDSYNCSTAT"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "diff_content<<ENDSYNCDIFF"
+            echo "$DIFF_CONTENT"
+            echo "ENDSYNCDIFF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare review prompt
+        if: steps.detect.outputs.has_changes == 'true'
+        id: review_prompt
+        env:
+          DIFF_STAT: ${{ steps.sync_diff.outputs.diff_stat }}
+          DIFF_CONTENT: ${{ steps.sync_diff.outputs.diff_content }}
+          EXTRA_INSTRUCTIONS: ${{ github.event.inputs.extra_instructions }}
+        run: |
+          envsubst '$DIFF_STAT $DIFF_CONTENT $EXTRA_INSTRUCTIONS' \
+            < .github/prompts/review-sync.md > /tmp/review.md
+          {
+            echo "value<<ENDREVIEW"
+            cat /tmp/review.md
+            echo "ENDREVIEW"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Codex to review sync
+        if: steps.detect.outputs.has_changes == 'true'
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL }}
+          model: ${{ github.event.inputs.model || 'gpt-5.5' }}
+          sandbox: danger-full-access
+          safety-strategy: drop-sudo
+          prompt: ${{ steps.review_prompt.outputs.value }}
+
+      - name: Clean up artifacts
+        if: steps.detect.outputs.has_changes == 'true'
+        run: rm -rf picoclaw-upstream .codex .pr-update.md
+
+      - name: Verify build
+        if: steps.detect.outputs.has_changes == 'true'
+        run: |
+          npm ci
+          npm run build
+
+      - name: Read PR summary from Codex
+        if: steps.detect.outputs.has_changes == 'true'
+        id: pr_meta
+        run: |
+          if [ -f .pr-summary.md ]; then
+            PR_TITLE=$(head -1 .pr-summary.md | sed 's/^title: *//')
+            PR_BODY=$(sed '1d; /^---$/,$ { /^---$/d; b }; d' .pr-summary.md)
+            rm -f .pr-summary.md
+          else
+            PR_TITLE=""
+            PR_BODY=""
+          fi
+          echo "title=${PR_TITLE}" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<ENDPRBODY"
+            echo "$PR_BODY"
+            echo "ENDPRBODY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        if: steps.detect.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: ${{ steps.pr_meta.outputs.title || format('docs: sync with upstream picoclaw {0}', steps.ref.outputs.label) }}
+          commit-message: |
+            docs: sync with upstream picoclaw ${{ steps.ref.outputs.label }}
+
+            Synced documentation to match upstream changes since ${{ steps.detect.outputs.old_commit }}.
+
+            Co-Authored-By: Codex <noreply@openai.com>
+          branch: ai/sync-upstream-${{ steps.ref.outputs.label }}
+          delete-branch: true
+          labels: automated,sync
+          body: |
+            ## Summary
+
+            Automated documentation sync with upstream [sipeed/picoclaw](https://github.com/sipeed/picoclaw).
+
+            - **Target**: `${{ steps.ref.outputs.label }}`
+            - **Synced range**: `${{ steps.detect.outputs.old_commit }}`..`${{ steps.detect.outputs.new_commit }}`
+            - **Trigger**: ${{ github.event_name }}
+
+            ### Changes made
+            ${{ steps.pr_meta.outputs.body || '_No summary generated by Codex._' }}
+
+            ### Upstream commits included
+            ```
+            ${{ steps.detect.outputs.commit_log }}
+            ```
+
+            ### Files changed upstream
+            ```
+            ${{ steps.detect.outputs.diff_stat }}
+            ```
+
+            ---
+            > This PR was generated by Codex via GitHub Actions. Please review carefully before merging.

--- a/.github/workflows/tag-on-sync-merge.yml
+++ b/.github/workflows/tag-on-sync-merge.yml
@@ -1,0 +1,46 @@
+name: Tag docs on sync PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: >
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'sync') &&
+      startsWith(github.event.pull_request.head.ref, 'ai/sync-upstream-v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract tag from branch name
+        id: extract
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # ai/sync-upstream-v0.3.0 -> v0.3.0
+          TAG="${BRANCH#ai/sync-upstream-}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Extracted tag: $TAG"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Create and push tag
+        env:
+          TAG: ${{ steps.extract.outputs.tag }}
+        run: |
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "::warning::Tag '$TAG' already exists on docs repo, skipping."
+          else
+            git tag -a "$TAG" -m "docs: sync with upstream picoclaw $TAG"
+            git push origin "$TAG"
+            echo "Tagged docs repo with $TAG"
+          fi


### PR DESCRIPTION
- sync-upstream.yml: workflow_dispatch to sync docs with sipeed/picoclaw via Codex, with tag support and two-pass (sync + review) pipeline
- chatops.yml: /fix slash command for iterative PR fixes
- fix-on-review.yml: auto-fix on "Request Changes" review
- tag-on-sync-merge.yml: auto-tag docs repo on sync PR merge
- detect-changes.sh: upstream change detection script
- sync-docs.md / review-sync.md: Codex prompt templates