### PR TITLE
fix(ci): quote YAML expression in sync-upstream PR title

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -198,7 +198,7 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          title: ${{ steps.pr_meta.outputs.title || format('docs: sync with upstream picoclaw {0}', steps.ref.outputs.label) }}
+          title: "${{ steps.pr_meta.outputs.title || format('docs: sync with upstream picoclaw {0}', steps.ref.outputs.label) }}"
           commit-message: |
             docs: sync with upstream picoclaw ${{ steps.ref.outputs.label }}
 


### PR DESCRIPTION
The unquoted `${{ format() }}` expression caused GitHub to reject the workflow file with "Invalid workflow file" YAML syntax error.