### PR TITLE
fix(ci): address audit findings for workflow reliability

### DIFF
--- a/.github/prompts/review-sync.md
+++ b/.github/prompts/review-sync.md
@@ -18,7 +18,7 @@ ${DIFF_CONTENT}
 Go through each item carefully:
 
 ### 1. No unwanted files
-- `picoclaw-upstream/`, `.codex`, `node_modules/`, `.pr-summary.md` must NOT appear in `git diff --stat HEAD`.
+- `picoclaw-upstream/`, `.codex`, `node_modules/` must NOT appear in `git diff --stat HEAD`.
 - If found, revert with `git checkout -- <path>` or `rm -rf <path>`.
 
 ### 2. No regressions

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -141,7 +141,9 @@ jobs:
         run: rm -rf picoclaw-upstream .codex
 
       - name: Verify build
-        run: npm run build
+        run: |
+          npm ci
+          npm run build
 
       - name: Update PR metadata
         env:

--- a/.github/workflows/fix-on-review.yml
+++ b/.github/workflows/fix-on-review.yml
@@ -137,7 +137,9 @@ jobs:
         run: rm -rf picoclaw-upstream .codex
 
       - name: Verify build
-        run: npm run build
+        run: |
+          npm ci
+          npm run build
 
       - name: Update PR metadata
         env:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -110,6 +110,11 @@ jobs:
             echo "ENDOFPROMPT"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Save pre-Codex HEAD
+        if: steps.detect.outputs.has_changes == 'true'
+        id: pre_codex
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Run Codex to sync docs
         if: steps.detect.outputs.has_changes == 'true'
         uses: openai/codex-action@v1
@@ -121,12 +126,33 @@ jobs:
           safety-strategy: drop-sudo
           prompt: ${{ steps.prompt.outputs.value }}
 
+      - name: Read PR summary from Codex
+        if: steps.detect.outputs.has_changes == 'true'
+        id: pr_meta
+        run: |
+          if [ -f .pr-summary.md ]; then
+            PR_TITLE=$(head -1 .pr-summary.md | sed 's/^title: *//')
+            PR_BODY=$(sed '1d; /^---$/,$ { /^---$/d; b }; d' .pr-summary.md)
+            rm -f .pr-summary.md
+          else
+            PR_TITLE=""
+            PR_BODY=""
+          fi
+          echo "title=${PR_TITLE}" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<ENDPRBODY"
+            echo "$PR_BODY"
+            echo "ENDPRBODY"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Capture sync diff for review
         if: steps.detect.outputs.has_changes == 'true'
         id: sync_diff
+        env:
+          PRE_CODEX_SHA: ${{ steps.pre_codex.outputs.sha }}
         run: |
-          DIFF_STAT=$(git diff --stat HEAD)
-          DIFF_CONTENT=$(git diff HEAD -- ':!picoclaw-upstream' ':!.codex' | head -3000)
+          DIFF_STAT=$(git diff --stat "$PRE_CODEX_SHA")
+          DIFF_CONTENT=$(git diff "$PRE_CODEX_SHA" -- ':!picoclaw-upstream' ':!.codex' | head -3000)
           {
             echo "diff_stat<<ENDSYNCSTAT"
             echo "$DIFF_STAT"
@@ -154,6 +180,10 @@ jobs:
             echo "ENDREVIEW"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Reset Codex config for second pass
+        if: steps.detect.outputs.has_changes == 'true'
+        run: rm -f /home/runner/.codex/config.toml
+
       - name: Run Codex to review sync
         if: steps.detect.outputs.has_changes == 'true'
         uses: openai/codex-action@v1
@@ -162,7 +192,7 @@ jobs:
           responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL }}
           model: ${{ github.event.inputs.model || 'gpt-5.5' }}
           sandbox: danger-full-access
-          safety-strategy: drop-sudo
+          safety-strategy: unsafe
           prompt: ${{ steps.review_prompt.outputs.value }}
 
       - name: Clean up artifacts
@@ -174,25 +204,6 @@ jobs:
         run: |
           npm ci
           npm run build
-
-      - name: Read PR summary from Codex
-        if: steps.detect.outputs.has_changes == 'true'
-        id: pr_meta
-        run: |
-          if [ -f .pr-summary.md ]; then
-            PR_TITLE=$(head -1 .pr-summary.md | sed 's/^title: *//')
-            PR_BODY=$(sed '1d; /^---$/,$ { /^---$/d; b }; d' .pr-summary.md)
-            rm -f .pr-summary.md
-          else
-            PR_TITLE=""
-            PR_BODY=""
-          fi
-          echo "title=${PR_TITLE}" >> "$GITHUB_OUTPUT"
-          {
-            echo "body<<ENDPRBODY"
-            echo "$PR_BODY"
-            echo "ENDPRBODY"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Create pull request
         if: steps.detect.outputs.has_changes == 'true'


### PR DESCRIPTION
- Use safety-strategy: none for second Codex pass (drop-sudo already removed sudo in first pass, second call fails without this)
- Move "Read PR summary" before review Codex step to prevent review agent from deleting .pr-summary.md before it's read
- Save pre-Codex HEAD and diff against it so review agent sees changes even when Codex committed directly in danger-full-access mode
- Add npm ci before post-Codex build verification in chatops and fix-on-review (Codex may corrupt node_modules)
- Remove .pr-summary.md from review-sync.md unwanted files list