### PR TITLE
docs(cli): merge CLI-REFERENCE into cli-parameters across all locales

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -136,3 +136,5 @@ Besides chat slash commands, the `picoclaw` binary also provides Cobra CLI subco
 `picoclaw onboard` · `picoclaw agent` · `picoclaw auth` · `picoclaw gateway` · `picoclaw status` · `picoclaw cron` · `picoclaw mcp` · `picoclaw migrate` · `picoclaw skills` · `picoclaw model` · `picoclaw update` · `picoclaw version`
 
 These CLI commands and chat commands are separate entry points: CLI commands run in the terminal, while chat commands are triggered through channel messages such as Telegram, Feishu, WeChat, etc.
+
+For detailed CLI command documentation, see [CLI Commands and Parameters](/docs/configuration/cli-parameters).

--- a/docs/configuration/cli-parameters.md
+++ b/docs/configuration/cli-parameters.md
@@ -5,27 +5,778 @@ title: CLI Commands and Parameters
 
 # CLI Commands and Parameters
 
-## Core CLI Commands
+PicoClaw is a lightweight personal AI assistant. This page documents all CLI commands and parameters supported by the `picoclaw` binary.
 
-| Command | Description |
+:::tip
+For chat slash commands (e.g. `/help`, `/clear`), see [Chat Command Reference](/docs/chat-commands).
+:::
+
+## Global Parameters
+
+| Parameter | Description |
 | --- | --- |
-| `picoclaw onboard` | Initialize config and workspace |
-| `picoclaw agent -m "hello"` | One-shot chat |
-| `picoclaw agent` | Interactive chat mode |
-| `picoclaw gateway` | Start the gateway (for chat apps) |
-| `picoclaw status` | Show status |
-| `picoclaw cron list` | List all scheduled jobs |
-| `picoclaw cron add ...` | Add a scheduled job |
+| `--no-color` | Disable colored output (preserves border layout) |
+
+You can also disable colors via the `NO_COLOR` environment variable or `TERM=dumb`.
+
+---
+
+## Command Overview
+
+| Command | Alias | Description |
+| --- | --- | --- |
+| [`picoclaw onboard`](#picoclaw-onboard) | `o` | Initialize config and workspace |
+| [`picoclaw agent`](#picoclaw-agent) | | Interact with the AI agent |
+| [`picoclaw auth`](#picoclaw-auth) | | Manage authentication (login, logout, status) |
+| [`picoclaw gateway`](#picoclaw-gateway) | `g` | Start the PicoClaw gateway |
+| [`picoclaw status`](#picoclaw-status) | `s` | Show PicoClaw status |
+| [`picoclaw cron`](#picoclaw-cron) | `c` | Manage scheduled tasks |
+| [`picoclaw mcp`](#picoclaw-mcp) | | Manage MCP server configurations |
+| [`picoclaw migrate`](#picoclaw-migrate) | | Migrate from other tools to PicoClaw |
+| [`picoclaw skills`](#picoclaw-skills) | | Manage skills |
+| [`picoclaw model`](#picoclaw-model) | | View or change the default model |
+| [`picoclaw update`](#picoclaw-update) | | Update PicoClaw |
+| [`picoclaw version`](#picoclaw-version) | `v` | Show version information |
+
+---
+
+## picoclaw onboard
+
+Initialize PicoClaw configuration and workspace.
+
+```bash
+picoclaw onboard [flags]
+```
+
+### Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `--enc` | Enable credential encryption (generates SSH key and prompts for passphrase) |
+
+### Examples
+
+```bash
+picoclaw onboard
+picoclaw onboard --enc
+```
+
+---
+
+## picoclaw agent
+
+Interact directly with the AI agent.
+
+```bash
+picoclaw agent [flags]
+```
+
+### Parameters
+
+| Parameter | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--debug` | `-d` | `false` | Enable debug logging |
+| `--message` | `-m` | | Send a single message (non-interactive mode) |
+| `--session` | `-s` | `cli:default` | Session key |
+| `--model` | | | Model to use |
+
+### Examples
+
+```bash
+# Interactive mode
+picoclaw agent
+
+# Non-interactive mode
+picoclaw agent -m "Hello, how are you?"
+
+# Specify model
+picoclaw agent --model gpt-5.2 -m "Explain quantum computing"
+```
+
+---
+
+## picoclaw auth
+
+Manage authentication, including login, logout, and status.
+
+```bash
+picoclaw auth [command]
+```
+
+### Subcommands
+
+- [`login`](#picoclaw-auth-login) - Login
+- [`logout`](#picoclaw-auth-logout) - Logout
+- [`status`](#picoclaw-auth-status) - Show authentication status
+- [`models`](#picoclaw-auth-models) - Show available models
+- [`weixin`](#picoclaw-auth-weixin) - Connect WeChat personal account
+- [`wecom`](#picoclaw-auth-wecom) - Connect WeCom (Enterprise WeChat)
+
+---
+
+### picoclaw auth login
+
+Login via OAuth or paste token.
+
+```bash
+picoclaw auth login [flags]
+```
+
+#### Parameters
+
+| Parameter | Short | Description |
+| --- | --- | --- |
+| `--provider` | `-p` | **Required**. Login provider (`openai`, `anthropic`, `google-antigravity`, `antigravity`) |
+| `--device-code` | | Use device code flow (for headless environments) |
+| `--no-browser` | | Do not auto-open browser for OAuth login |
+| `--setup-token` | | Use Anthropic's setup-token flow |
+
+#### Examples
+
+```bash
+picoclaw auth login -p openai
+picoclaw auth login -p anthropic --setup-token
+picoclaw auth login -p openai --device-code
+```
+
+---
+
+### picoclaw auth logout
+
+Remove stored credentials.
+
+```bash
+picoclaw auth logout [flags]
+```
+
+#### Parameters
+
+| Parameter | Short | Description |
+| --- | --- | --- |
+| `--provider` | `-p` | Provider to logout from (`openai`, `anthropic`); empty = logout all |
+
+#### Examples
+
+```bash
+picoclaw auth logout -p openai
+picoclaw auth logout
+```
+
+---
+
+### picoclaw auth status
+
+Show current authentication status.
+
+```bash
+picoclaw auth status
+```
+
+---
+
+### picoclaw auth models
+
+Show available models.
+
+```bash
+picoclaw auth models
+```
+
+---
+
+### picoclaw auth weixin
+
+Connect WeChat personal account via QR code.
+
+```bash
+picoclaw auth weixin [flags]
+```
+
+#### Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `--base-url` | `https://ilinkai.weixin.qq.com/` | iLink API base URL |
+| `--proxy` | | HTTP proxy URL (e.g. `http://localhost:7890`) |
+| `--timeout` | `300` | Login timeout in seconds |
+
+#### Examples
+
+```bash
+picoclaw auth weixin
+picoclaw auth weixin --proxy http://localhost:7890
+```
+
+---
+
+### picoclaw auth wecom
+
+Scan WeCom QR code and configure `channels.wecom`.
+
+```bash
+picoclaw auth wecom [flags]
+```
+
+#### Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `--timeout` | `5m` | Timeout waiting for QR code confirmation |
+
+#### Examples
+
+```bash
+picoclaw auth wecom
+picoclaw auth wecom --timeout 10m
+```
+
+---
+
+## picoclaw gateway
+
+Start the PicoClaw gateway service.
+
+```bash
+picoclaw gateway [flags]
+```
+
+### Parameters
+
+| Parameter | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--debug` | `-d` | `false` | Enable debug logging |
+| `--no-truncate` | `-T` | `false` | Disable string truncation in debug logs (must be used with `--debug`) |
+| `--allow-empty` | `-E` | `false` | Continue startup even when no default model is configured |
+| `--host` | | | Gateway bind host address (overrides `gateway.host` config) |
+
+### Examples
+
+```bash
+picoclaw gateway
+picoclaw gateway -d
+picoclaw gateway -d -T
+picoclaw gateway --host 0.0.0.0
+```
+
+---
+
+## picoclaw status
+
+Show current PicoClaw status.
+
+```bash
+picoclaw status
+```
+
+---
+
+## picoclaw cron
+
+Manage scheduled tasks.
+
+:::tip
+For detailed documentation on schedule types, execution modes, and configuration, see [Scheduled Tasks & Cron Jobs](/docs/cron).
+:::
+
+```bash
+picoclaw cron [command]
+```
+
+### Subcommands
+
+- `list` - List all scheduled jobs
+- `add` - Add a new job
+- `remove` - Remove a job by ID
+- `enable` - Enable a job
+- `disable` - Disable a job
+
+### picoclaw cron add
+
+```bash
+picoclaw cron add [flags]
+```
+
+#### Parameters
+
+| Parameter | Short | Description |
+| --- | --- | --- |
+| `--name` | `-n` | **Required**. Job name |
+| `--message` | `-m` | **Required**. Message to send to the agent |
+| `--every` | `-e` | Run every N seconds |
+| `--cron` | `-c` | Cron expression (e.g. `0 9 * * *`) |
+| `--to` | | Recipient |
+| `--channel` | | Delivery channel |
+
+> **Note**: `--every` and `--cron` are mutually exclusive; one must be specified.
+
+#### Examples
+
+```bash
+# Run every 60 seconds
+picoclaw cron add -n "health-check" -m "Check system health" -e 60
+
+# Run daily at 9am
+picoclaw cron add -n "morning-report" -m "Generate morning report" -c "0 9 * * *"
+
+# Specify delivery channel
+picoclaw cron add -n "reminder" -m "Take a break" -e 1800 --channel wecom --to user123
+```
+
+### Other cron subcommands
+
+```bash
+picoclaw cron list
+picoclaw cron remove <job-id>
+picoclaw cron enable <job-id>
+picoclaw cron disable <job-id>
+```
+
+---
+
+## picoclaw mcp
+
+Manage MCP (Model Context Protocol) server configurations.
+
+```bash
+picoclaw mcp [command]
+```
+
+### Subcommands
+
+- [`add`](#picoclaw-mcp-add) - Add or update an MCP server
+- [`remove`](#picoclaw-mcp-remove) - Remove an MCP server
+- [`list`](#picoclaw-mcp-list) - List configured MCP servers
+- [`edit`](#picoclaw-mcp-edit) - Open config in editor
+- [`test`](#picoclaw-mcp-test) - Test MCP server connection
+- [`show`](#picoclaw-mcp-show) - Show MCP server details
+
+---
+
+### picoclaw mcp add
+
+Add or update an MCP server.
+
+```bash
+picoclaw mcp add [flags] <name> <command-or-url> [args...]
+```
+
+#### Parameters
+
+| Parameter | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--env` | `-e` | | Environment variable in `KEY=value` format (repeatable) |
+| `--env-file` | | | Path to environment variable file (recommended for secrets) |
+| `--header` | `-H` | | HTTP header in `Name: Value` or `Name=Value` format (repeatable) |
+| `--transport` | `-t` | `stdio` | Transport type: `stdio`, `http`, or `sse` |
+| `--force` | `-f` | `false` | Overwrite existing server without prompting |
+| `--deferred` | | `false` | Mark as deferred loading (tools hidden until explicitly activated) |
+| `--no-deferred` | | `false` | Mark as non-deferred (tools always active) |
+
+#### Examples
+
+```bash
+# Add stdio MCP server
+picoclaw mcp add my-server /path/to/server arg1 arg2
+
+# Add http MCP server
+picoclaw mcp add remote-server https://example.com/mcp --transport http
+
+# Add with environment variables
+picoclaw mcp add my-server /path/to/server -e API_KEY=xxx -e DEBUG=true
+
+# Use env file
+picoclaw mcp add my-server /path/to/server --env-file .env
+
+# Force overwrite
+picoclaw mcp add my-server /path/to/new-server --force
+```
+
+---
+
+### picoclaw mcp remove
+
+Remove an MCP server.
+
+```bash
+picoclaw mcp remove <name>
+```
+
+---
+
+### picoclaw mcp list
+
+List configured MCP servers.
+
+```bash
+picoclaw mcp list [flags]
+```
+
+#### Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `--status` | `false` | Ping enabled servers and show live status |
+| `--timeout` | `5s` | Timeout per status check |
+
+#### Examples
+
+```bash
+picoclaw mcp list
+picoclaw mcp list --status
+picoclaw mcp list --status --timeout 10s
+```
+
+---
+
+### picoclaw mcp edit
+
+Open the PicoClaw config file in `$EDITOR`.
+
+```bash
+picoclaw mcp edit
+```
+
+> **Note**: Requires the `EDITOR` environment variable to be set.
+
+---
+
+### picoclaw mcp test
+
+Test MCP server connection.
+
+```bash
+picoclaw mcp test <name> [flags]
+```
+
+#### Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `--timeout` | `5s` | Connection timeout |
+
+#### Examples
+
+```bash
+picoclaw mcp test my-server
+picoclaw mcp test my-server --timeout 10s
+```
+
+---
+
+### picoclaw mcp show
+
+Show MCP server details and tool list.
+
+```bash
+picoclaw mcp show <name> [flags]
+```
+
+#### Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `--timeout` | `10s` | Connection timeout |
+
+#### Examples
+
+```bash
+picoclaw mcp show my-server
+picoclaw mcp show my-server --timeout 15s
+```
+
+---
+
+## picoclaw migrate
+
+Migrate from other tools (e.g. OpenClaw) to PicoClaw.
+
+```bash
+picoclaw migrate [flags]
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `--dry-run` | `false` | Show what would be migrated without making changes |
+| `--from` | `openclaw` | Migration source (e.g. `openclaw`) |
+| `--refresh` | `false` | Re-sync workspace files from OpenClaw |
+| `--config-only` | `false` | Migrate config only, skip workspace files |
+| `--workspace-only` | `false` | Migrate workspace files only, skip config |
+| `--force` | `false` | Skip confirmation prompts |
+| `--source-home` | `~/.openclaw` | Override source directory |
+| `--target-home` | `~/.picoclaw` | Override target directory |
+
+### Examples
+
+```bash
+# Default migration
+picoclaw migrate
+
+# Preview migration
+picoclaw migrate --dry-run
+
+# Config only
+picoclaw migrate --config-only
+
+# Force migration
+picoclaw migrate --force
+```
+
+---
+
+## picoclaw skills
+
+Manage skills.
+
+```bash
+picoclaw skills [command]
+```
+
+### Subcommands
+
+- [`list`](#picoclaw-skills-list) - List installed skills
+- [`install`](#picoclaw-skills-install) - Install from GitHub or registry
+- [`install-builtin`](#picoclaw-skills-install-builtin) - Install all built-in skills
+- [`list-builtin`](#picoclaw-skills-list-builtin) - List available built-in skills
+- [`remove`](#picoclaw-skills-remove) - Remove an installed skill
+- [`search`](#picoclaw-skills-search) - Search available skills
+- [`show`](#picoclaw-skills-show) - Show skill details
+
+---
+
+### picoclaw skills list
+
+List installed skills.
+
+```bash
+picoclaw skills list
+```
+
+---
+
+### picoclaw skills install
+
+Install from GitHub or registry.
+
+```bash
+picoclaw skills install <github> [flags]
+picoclaw skills install --registry <name> <slug>
+```
+
+#### Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `--registry` | Install from specified registry |
+
+#### Examples
+
+```bash
+# Install from GitHub
+picoclaw skills install sipeed/picoclaw-skills/weather
+
+# Install from registry
+picoclaw skills install --registry clawhub github
+```
+
+---
+
+### picoclaw skills install-builtin
+
+Install all built-in skills to workspace.
+
+```bash
+picoclaw skills install-builtin
+```
+
+---
+
+### picoclaw skills list-builtin
+
+List available built-in skills.
+
+```bash
+picoclaw skills list-builtin
+```
+
+---
+
+### picoclaw skills remove
+
+Remove an installed skill.
+
+```bash
+picoclaw skills remove <name>
+```
+
+> **Aliases**: `rm`, `uninstall`
+
+#### Examples
+
+```bash
+picoclaw skills remove weather
+picoclaw skills rm weather
+picoclaw skills uninstall weather
+```
+
+---
+
+### picoclaw skills search
+
+Search available skills.
+
+```bash
+picoclaw skills search [query]
+```
+
+#### Examples
+
+```bash
+# List all skills
+picoclaw skills search
+
+# Search for a specific skill
+picoclaw skills search weather
+```
+
+---
+
+### picoclaw skills show
+
+Show skill details.
+
+```bash
+picoclaw skills show <name>
+```
+
+#### Examples
+
+```bash
+picoclaw skills show weather
+```
+
+---
+
+## picoclaw model
+
+View or change the default model.
+
+```bash
+picoclaw model [model_name] [command]
+```
+
+### Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `model_name` | Optional. Model name to set as default |
+
+### Subcommands
+
+- [`add`](#picoclaw-model-add) - Add a model from an OpenAI-compatible endpoint
+
+### Examples
+
+```bash
+# Show current default model
+picoclaw model
+
+# Set default model
+picoclaw model gpt-5.2
+picoclaw model claude-sonnet-4.6
+picoclaw model local-model
+```
+
+---
+
+### picoclaw model add
+
+Add a model from an OpenAI-compatible endpoint and set it as default.
+
+```bash
+picoclaw model add [flags]
+```
+
+#### Parameters
+
+| Parameter | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--api-base` | `-b` | | **Required**. API base URL |
+| `--api-key` | `-k` | | **Required**. API key |
+| `--model` | `-m` | | Model ID; skips interactive selection and network calls when set |
+| `--name` | `-n` | `custom-prefer` | Local alias, written to model_list and used as default model name |
+| `--type` | | `openai-compatible` | Endpoint type (currently only `openai-compatible`) |
+
+#### Examples
+
+```bash
+# Interactive model selection
+picoclaw model add -b https://api.openai.com/v1 -k sk-xxx
+
+# Specify model directly
+picoclaw model add -b http://localhost:8000/v1 -k dummy -m my-model -n local
+```
+
+---
+
+## picoclaw update
+
+Update PicoClaw to the latest version.
+
+```bash
+picoclaw update
+```
+
+---
+
+## picoclaw version
+
+Show version information.
+
+```bash
+picoclaw version
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `NO_COLOR` | Set to any non-empty value to disable colored output |
+| `TERM` | Set to `dumb` to disable colored output |
+| `TZ` | Set timezone |
+| `EDITOR` | Editor for `picoclaw mcp edit` command |
+| `GATEWAY_HOST` | Gateway bind host address (can be overridden by `--host` flag) |
+
+---
+
+## Configuration File
+
+PicoClaw's config file is located at `~/.picoclaw/config.json` by default. You can view and edit it with:
+
+```bash
+# Show config path
+picoclaw status
+
+# Edit config
+picoclaw mcp edit
+```
+
+---
 
 ## `picoclaw-launcher` Parameters
+
+The `picoclaw-launcher` binary provides the GUI launcher with the following parameters:
 
 | Parameter | Description | Example |
 | --- | --- | --- |
 | `-console` | Run in terminal mode (no tray GUI), prints login hint/token source in console startup output | `picoclaw-launcher -console` |
 | `-public` | Listen on `0.0.0.0`, allow LAN devices to access WebUI | `picoclaw-launcher -public` |
 | `-no-browser` | Do not auto-open browser on startup | `picoclaw-launcher -no-browser` |
-| `-port &lt;port&gt;` | Specify launcher port (default `18800`) | `picoclaw-launcher -port 19999` |
-| `-lang &lt;en|zh&gt;` | Set launcher UI language | `picoclaw-launcher -lang zh` |
+| `-port <port>` | Specify launcher port (default `18800`) | `picoclaw-launcher -port 19999` |
+| `-lang <en\|zh>` | Set launcher UI language | `picoclaw-launcher -lang zh` |
 | `[config.json]` | Optional positional config path | `picoclaw-launcher ./config.json` |
 
 Common combinations:
@@ -36,4 +787,24 @@ picoclaw-launcher -console -no-browser -public
 
 # Custom port with explicit config file
 picoclaw-launcher -port 19999 ./config.json
+```
+
+---
+
+## Getting Help
+
+Get detailed help for any command:
+
+```bash
+picoclaw --help
+picoclaw <command> --help
+picoclaw <command> <subcommand> --help
+```
+
+Examples:
+
+```bash
+picoclaw mcp add --help
+picoclaw cron add --help
+picoclaw model add --help
 ```

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/chat-commands.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/chat-commands.md
@@ -136,3 +136,5 @@ Além dos comandos slash de chat, o binário `picoclaw` também oferece subcoman
 `picoclaw onboard` · `picoclaw agent` · `picoclaw auth` · `picoclaw gateway` · `picoclaw status` · `picoclaw cron` · `picoclaw mcp` · `picoclaw migrate` · `picoclaw skills` · `picoclaw model` · `picoclaw update` · `picoclaw version`
 
 Esses comandos CLI e comandos de chat são pontos de entrada separados: comandos CLI são executados no terminal, enquanto comandos de chat são acionados por mensagens de canais como Telegram, Feishu, WeChat, etc.
+
+Para documentação detalhada dos comandos CLI, veja [Comandos e Parâmetros CLI](/docs/configuration/cli-parameters).

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/configuration/cli-parameters.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/configuration/cli-parameters.md
@@ -5,27 +5,778 @@ title: Comandos e Parâmetros CLI
 
 # Comandos e Parâmetros CLI
 
-## Comandos principais da CLI
+O PicoClaw é um assistente de IA pessoal leve. Esta página documenta todos os comandos e parâmetros CLI suportados pelo binário `picoclaw`.
 
-| Comando | Descrição |
+:::tip
+Para comandos slash de chat (ex. `/help`, `/clear`), veja [Referência de Comandos de Chat](/docs/chat-commands).
+:::
+
+## Parâmetros Globais
+
+| Parâmetro | Descrição |
 | --- | --- |
-| `picoclaw onboard` | Inicializa configuração e workspace |
-| `picoclaw agent -m "hello"` | Chat de uma rodada |
-| `picoclaw agent` | Modo de chat interativo |
-| `picoclaw gateway` | Inicia o gateway (para apps de chat) |
-| `picoclaw status` | Mostra o status |
-| `picoclaw cron list` | Lista todas as tarefas agendadas |
-| `picoclaw cron add ...` | Adiciona uma tarefa agendada |
+| `--no-color` | Desabilita saída colorida (preserva layout de bordas) |
+
+Você também pode desabilitar cores através da variável de ambiente `NO_COLOR` ou `TERM=dumb`.
+
+---
+
+## Visão Geral dos Comandos
+
+| Comando | Alias | Descrição |
+| --- | --- | --- |
+| [`picoclaw onboard`](#picoclaw-onboard) | `o` | Inicializa configuração e workspace |
+| [`picoclaw agent`](#picoclaw-agent) | | Interage com o agente de IA |
+| [`picoclaw auth`](#picoclaw-auth) | | Gerencia autenticação (login, logout, status) |
+| [`picoclaw gateway`](#picoclaw-gateway) | `g` | Inicia o gateway do PicoClaw |
+| [`picoclaw status`](#picoclaw-status) | `s` | Mostra o status do PicoClaw |
+| [`picoclaw cron`](#picoclaw-cron) | `c` | Gerencia tarefas agendadas |
+| [`picoclaw mcp`](#picoclaw-mcp) | | Gerencia configurações de servidores MCP |
+| [`picoclaw migrate`](#picoclaw-migrate) | | Migra de outras ferramentas para o PicoClaw |
+| [`picoclaw skills`](#picoclaw-skills) | | Gerencia skills |
+| [`picoclaw model`](#picoclaw-model) | | Visualiza ou altera o modelo padrão |
+| [`picoclaw update`](#picoclaw-update) | | Atualiza o PicoClaw |
+| [`picoclaw version`](#picoclaw-version) | `v` | Mostra informações de versão |
+
+---
+
+## picoclaw onboard
+
+Inicializa a configuração e workspace do PicoClaw.
+
+```bash
+picoclaw onboard [flags]
+```
+
+### Parâmetros
+
+| Parâmetro | Descrição |
+| --- | --- |
+| `--enc` | Habilita criptografia de credenciais (gera chave SSH e solicita senha) |
+
+### Exemplos
+
+```bash
+picoclaw onboard
+picoclaw onboard --enc
+```
+
+---
+
+## picoclaw agent
+
+Interage diretamente com o agente de IA.
+
+```bash
+picoclaw agent [flags]
+```
+
+### Parâmetros
+
+| Parâmetro | Curto | Padrão | Descrição |
+| --- | --- | --- | --- |
+| `--debug` | `-d` | `false` | Habilita logging de debug |
+| `--message` | `-m` | | Envia uma única mensagem (modo não interativo) |
+| `--session` | `-s` | `cli:default` | Chave de sessão |
+| `--model` | | | Modelo a ser usado |
+
+### Exemplos
+
+```bash
+# Modo interativo
+picoclaw agent
+
+# Modo não interativo
+picoclaw agent -m "Hello, how are you?"
+
+# Especificar modelo
+picoclaw agent --model gpt-5.2 -m "Explain quantum computing"
+```
+
+---
+
+## picoclaw auth
+
+Gerencia autenticação, incluindo login, logout e status.
+
+```bash
+picoclaw auth [command]
+```
+
+### Subcomandos
+
+- [`login`](#picoclaw-auth-login) - Login
+- [`logout`](#picoclaw-auth-logout) - Logout
+- [`status`](#picoclaw-auth-status) - Mostra status de autenticação
+- [`models`](#picoclaw-auth-models) - Mostra modelos disponíveis
+- [`weixin`](#picoclaw-auth-weixin) - Conecta conta pessoal do WeChat
+- [`wecom`](#picoclaw-auth-wecom) - Conecta WeCom (WeChat Empresarial)
+
+---
+
+### picoclaw auth login
+
+Login via OAuth ou colando token.
+
+```bash
+picoclaw auth login [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Curto | Descrição |
+| --- | --- | --- |
+| `--provider` | `-p` | **Obrigatório**. Provedor de login (`openai`, `anthropic`, `google-antigravity`, `antigravity`) |
+| `--device-code` | | Usa fluxo de código de dispositivo (para ambientes sem interface) |
+| `--no-browser` | | Não abre navegador automaticamente para login OAuth |
+| `--setup-token` | | Usa o fluxo setup-token da Anthropic |
+
+#### Exemplos
+
+```bash
+picoclaw auth login -p openai
+picoclaw auth login -p anthropic --setup-token
+picoclaw auth login -p openai --device-code
+```
+
+---
+
+### picoclaw auth logout
+
+Remove credenciais armazenadas.
+
+```bash
+picoclaw auth logout [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Curto | Descrição |
+| --- | --- | --- |
+| `--provider` | `-p` | Provedor para fazer logout (`openai`, `anthropic`); vazio = logout de todos |
+
+#### Exemplos
+
+```bash
+picoclaw auth logout -p openai
+picoclaw auth logout
+```
+
+---
+
+### picoclaw auth status
+
+Mostra o status de autenticação atual.
+
+```bash
+picoclaw auth status
+```
+
+---
+
+### picoclaw auth models
+
+Mostra modelos disponíveis.
+
+```bash
+picoclaw auth models
+```
+
+---
+
+### picoclaw auth weixin
+
+Conecta conta pessoal do WeChat via QR code.
+
+```bash
+picoclaw auth weixin [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Padrão | Descrição |
+| --- | --- | --- |
+| `--base-url` | `https://ilinkai.weixin.qq.com/` | URL base da API iLink |
+| `--proxy` | | URL do proxy HTTP (ex. `http://localhost:7890`) |
+| `--timeout` | `300` | Timeout de login em segundos |
+
+#### Exemplos
+
+```bash
+picoclaw auth weixin
+picoclaw auth weixin --proxy http://localhost:7890
+```
+
+---
+
+### picoclaw auth wecom
+
+Escaneia QR code do WeCom e configura `channels.wecom`.
+
+```bash
+picoclaw auth wecom [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Padrão | Descrição |
+| --- | --- | --- |
+| `--timeout` | `5m` | Timeout aguardando confirmação do QR code |
+
+#### Exemplos
+
+```bash
+picoclaw auth wecom
+picoclaw auth wecom --timeout 10m
+```
+
+---
+
+## picoclaw gateway
+
+Inicia o serviço gateway do PicoClaw.
+
+```bash
+picoclaw gateway [flags]
+```
+
+### Parâmetros
+
+| Parâmetro | Curto | Padrão | Descrição |
+| --- | --- | --- | --- |
+| `--debug` | `-d` | `false` | Habilita logging de debug |
+| `--no-truncate` | `-T` | `false` | Desabilita truncamento de strings nos logs de debug (deve ser usado com `--debug`) |
+| `--allow-empty` | `-E` | `false` | Continua a inicialização mesmo sem modelo padrão configurado |
+| `--host` | | | Endereço de host do gateway (sobrescreve config `gateway.host`) |
+
+### Exemplos
+
+```bash
+picoclaw gateway
+picoclaw gateway -d
+picoclaw gateway -d -T
+picoclaw gateway --host 0.0.0.0
+```
+
+---
+
+## picoclaw status
+
+Mostra o status atual do PicoClaw.
+
+```bash
+picoclaw status
+```
+
+---
+
+## picoclaw cron
+
+Gerencia tarefas agendadas.
+
+:::tip
+Para documentação detalhada sobre tipos de agendamento, modos de execução e configuração, veja [Tarefas Agendadas & Cron Jobs](/docs/cron).
+:::
+
+```bash
+picoclaw cron [command]
+```
+
+### Subcomandos
+
+- `list` - Lista todas as tarefas agendadas
+- `add` - Adiciona uma nova tarefa
+- `remove` - Remove uma tarefa por ID
+- `enable` - Habilita uma tarefa
+- `disable` - Desabilita uma tarefa
+
+### picoclaw cron add
+
+```bash
+picoclaw cron add [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Curto | Descrição |
+| --- | --- | --- |
+| `--name` | `-n` | **Obrigatório**. Nome da tarefa |
+| `--message` | `-m` | **Obrigatório**. Mensagem para enviar ao agente |
+| `--every` | `-e` | Executa a cada N segundos |
+| `--cron` | `-c` | Expressão cron (ex. `0 9 * * *`) |
+| `--to` | | Destinatário |
+| `--channel` | | Canal de entrega |
+
+> **Nota**: `--every` e `--cron` são mutuamente exclusivos; um deve ser especificado.
+
+#### Exemplos
+
+```bash
+# Executa a cada 60 segundos
+picoclaw cron add -n "health-check" -m "Check system health" -e 60
+
+# Executa diariamente às 9h
+picoclaw cron add -n "morning-report" -m "Generate morning report" -c "0 9 * * *"
+
+# Especificar canal de entrega
+picoclaw cron add -n "reminder" -m "Take a break" -e 1800 --channel wecom --to user123
+```
+
+### Outros subcomandos cron
+
+```bash
+picoclaw cron list
+picoclaw cron remove <job-id>
+picoclaw cron enable <job-id>
+picoclaw cron disable <job-id>
+```
+
+---
+
+## picoclaw mcp
+
+Gerencia configurações de servidores MCP (Model Context Protocol).
+
+```bash
+picoclaw mcp [command]
+```
+
+### Subcomandos
+
+- [`add`](#picoclaw-mcp-add) - Adiciona ou atualiza um servidor MCP
+- [`remove`](#picoclaw-mcp-remove) - Remove um servidor MCP
+- [`list`](#picoclaw-mcp-list) - Lista servidores MCP configurados
+- [`edit`](#picoclaw-mcp-edit) - Abre configuração no editor
+- [`test`](#picoclaw-mcp-test) - Testa conexão com servidor MCP
+- [`show`](#picoclaw-mcp-show) - Mostra detalhes do servidor MCP
+
+---
+
+### picoclaw mcp add
+
+Adiciona ou atualiza um servidor MCP.
+
+```bash
+picoclaw mcp add [flags] <name> <command-or-url> [args...]
+```
+
+#### Parâmetros
+
+| Parâmetro | Curto | Padrão | Descrição |
+| --- | --- | --- | --- |
+| `--env` | `-e` | | Variável de ambiente no formato `KEY=value` (repetível) |
+| `--env-file` | | | Caminho para arquivo de variáveis de ambiente (recomendado para segredos) |
+| `--header` | `-H` | | Cabeçalho HTTP no formato `Name: Value` ou `Name=Value` (repetível) |
+| `--transport` | `-t` | `stdio` | Tipo de transporte: `stdio`, `http` ou `sse` |
+| `--force` | `-f` | `false` | Sobrescreve servidor existente sem perguntar |
+| `--deferred` | | `false` | Marca como carregamento adiado (ferramentas ocultas até serem explicitamente ativadas) |
+| `--no-deferred` | | `false` | Marca como não adiado (ferramentas sempre ativas) |
+
+#### Exemplos
+
+```bash
+# Adicionar servidor MCP stdio
+picoclaw mcp add my-server /path/to/server arg1 arg2
+
+# Adicionar servidor MCP http
+picoclaw mcp add remote-server https://example.com/mcp --transport http
+
+# Adicionar com variáveis de ambiente
+picoclaw mcp add my-server /path/to/server -e API_KEY=xxx -e DEBUG=true
+
+# Usar arquivo de variáveis de ambiente
+picoclaw mcp add my-server /path/to/server --env-file .env
+
+# Forçar sobrescrita
+picoclaw mcp add my-server /path/to/new-server --force
+```
+
+---
+
+### picoclaw mcp remove
+
+Remove um servidor MCP.
+
+```bash
+picoclaw mcp remove <name>
+```
+
+---
+
+### picoclaw mcp list
+
+Lista servidores MCP configurados.
+
+```bash
+picoclaw mcp list [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Padrão | Descrição |
+| --- | --- | --- |
+| `--status` | `false` | Faz ping nos servidores habilitados e mostra status em tempo real |
+| `--timeout` | `5s` | Timeout por verificação de status |
+
+#### Exemplos
+
+```bash
+picoclaw mcp list
+picoclaw mcp list --status
+picoclaw mcp list --status --timeout 10s
+```
+
+---
+
+### picoclaw mcp edit
+
+Abre o arquivo de configuração do PicoClaw no `$EDITOR`.
+
+```bash
+picoclaw mcp edit
+```
+
+> **Nota**: Requer que a variável de ambiente `EDITOR` esteja configurada.
+
+---
+
+### picoclaw mcp test
+
+Testa conexão com servidor MCP.
+
+```bash
+picoclaw mcp test <name> [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Padrão | Descrição |
+| --- | --- | --- |
+| `--timeout` | `5s` | Timeout de conexão |
+
+#### Exemplos
+
+```bash
+picoclaw mcp test my-server
+picoclaw mcp test my-server --timeout 10s
+```
+
+---
+
+### picoclaw mcp show
+
+Mostra detalhes e lista de ferramentas do servidor MCP.
+
+```bash
+picoclaw mcp show <name> [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Padrão | Descrição |
+| --- | --- | --- |
+| `--timeout` | `10s` | Timeout de conexão |
+
+#### Exemplos
+
+```bash
+picoclaw mcp show my-server
+picoclaw mcp show my-server --timeout 15s
+```
+
+---
+
+## picoclaw migrate
+
+Migra de outras ferramentas (ex. OpenClaw) para o PicoClaw.
+
+```bash
+picoclaw migrate [flags]
+```
+
+### Parâmetros
+
+| Parâmetro | Padrão | Descrição |
+| --- | --- | --- |
+| `--dry-run` | `false` | Mostra o que seria migrado sem fazer alterações |
+| `--from` | `openclaw` | Fonte da migração (ex. `openclaw`) |
+| `--refresh` | `false` | Re-sincroniza arquivos do workspace do OpenClaw |
+| `--config-only` | `false` | Migra apenas configuração, pula arquivos do workspace |
+| `--workspace-only` | `false` | Migra apenas arquivos do workspace, pula configuração |
+| `--force` | `false` | Pula confirmações |
+| `--source-home` | `~/.openclaw` | Sobrescreve diretório de origem |
+| `--target-home` | `~/.picoclaw` | Sobrescreve diretório de destino |
+
+### Exemplos
+
+```bash
+# Migração padrão
+picoclaw migrate
+
+# Visualizar migração
+picoclaw migrate --dry-run
+
+# Apenas configuração
+picoclaw migrate --config-only
+
+# Forçar migração
+picoclaw migrate --force
+```
+
+---
+
+## picoclaw skills
+
+Gerencia skills.
+
+```bash
+picoclaw skills [command]
+```
+
+### Subcomandos
+
+- [`list`](#picoclaw-skills-list) - Lista skills instaladas
+- [`install`](#picoclaw-skills-install) - Instala do GitHub ou registro
+- [`install-builtin`](#picoclaw-skills-install-builtin) - Instala todas as skills embutidas
+- [`list-builtin`](#picoclaw-skills-list-builtin) - Lista skills embutidas disponíveis
+- [`remove`](#picoclaw-skills-remove) - Remove uma skill instalada
+- [`search`](#picoclaw-skills-search) - Pesquisa skills disponíveis
+- [`show`](#picoclaw-skills-show) - Mostra detalhes da skill
+
+---
+
+### picoclaw skills list
+
+Lista skills instaladas.
+
+```bash
+picoclaw skills list
+```
+
+---
+
+### picoclaw skills install
+
+Instala do GitHub ou registro.
+
+```bash
+picoclaw skills install <github> [flags]
+picoclaw skills install --registry <name> <slug>
+```
+
+#### Parâmetros
+
+| Parâmetro | Descrição |
+| --- | --- |
+| `--registry` | Instala do registro especificado |
+
+#### Exemplos
+
+```bash
+# Instalar do GitHub
+picoclaw skills install sipeed/picoclaw-skills/weather
+
+# Instalar do registro
+picoclaw skills install --registry clawhub github
+```
+
+---
+
+### picoclaw skills install-builtin
+
+Instala todas as skills embutidas no workspace.
+
+```bash
+picoclaw skills install-builtin
+```
+
+---
+
+### picoclaw skills list-builtin
+
+Lista skills embutidas disponíveis.
+
+```bash
+picoclaw skills list-builtin
+```
+
+---
+
+### picoclaw skills remove
+
+Remove uma skill instalada.
+
+```bash
+picoclaw skills remove <name>
+```
+
+> **Aliases**: `rm`, `uninstall`
+
+#### Exemplos
+
+```bash
+picoclaw skills remove weather
+picoclaw skills rm weather
+picoclaw skills uninstall weather
+```
+
+---
+
+### picoclaw skills search
+
+Pesquisa skills disponíveis.
+
+```bash
+picoclaw skills search [query]
+```
+
+#### Exemplos
+
+```bash
+# Listar todas as skills
+picoclaw skills search
+
+# Pesquisar uma skill específica
+picoclaw skills search weather
+```
+
+---
+
+### picoclaw skills show
+
+Mostra detalhes da skill.
+
+```bash
+picoclaw skills show <name>
+```
+
+#### Exemplos
+
+```bash
+picoclaw skills show weather
+```
+
+---
+
+## picoclaw model
+
+Visualiza ou altera o modelo padrão.
+
+```bash
+picoclaw model [model_name] [command]
+```
+
+### Parâmetros
+
+| Parâmetro | Descrição |
+| --- | --- |
+| `model_name` | Opcional. Nome do modelo para definir como padrão |
+
+### Subcomandos
+
+- [`add`](#picoclaw-model-add) - Adiciona um modelo de um endpoint compatível com OpenAI
+
+### Exemplos
+
+```bash
+# Mostrar modelo padrão atual
+picoclaw model
+
+# Definir modelo padrão
+picoclaw model gpt-5.2
+picoclaw model claude-sonnet-4.6
+picoclaw model local-model
+```
+
+---
+
+### picoclaw model add
+
+Adiciona um modelo de um endpoint compatível com OpenAI e o define como padrão.
+
+```bash
+picoclaw model add [flags]
+```
+
+#### Parâmetros
+
+| Parâmetro | Curto | Padrão | Descrição |
+| --- | --- | --- | --- |
+| `--api-base` | `-b` | | **Obrigatório**. URL base da API |
+| `--api-key` | `-k` | | **Obrigatório**. Chave da API |
+| `--model` | `-m` | | ID do modelo; pula seleção interativa e chamadas de rede quando definido |
+| `--name` | `-n` | `custom-prefer` | Alias local, gravado no model_list e usado como nome do modelo padrão |
+| `--type` | | `openai-compatible` | Tipo de endpoint (atualmente apenas `openai-compatible`) |
+
+#### Exemplos
+
+```bash
+# Seleção interativa de modelo
+picoclaw model add -b https://api.openai.com/v1 -k sk-xxx
+
+# Especificar modelo diretamente
+picoclaw model add -b http://localhost:8000/v1 -k dummy -m my-model -n local
+```
+
+---
+
+## picoclaw update
+
+Atualiza o PicoClaw para a versão mais recente.
+
+```bash
+picoclaw update
+```
+
+---
+
+## picoclaw version
+
+Mostra informações de versão.
+
+```bash
+picoclaw version
+```
+
+---
+
+## Variáveis de Ambiente
+
+| Variável | Descrição |
+| --- | --- |
+| `NO_COLOR` | Defina como qualquer valor não vazio para desabilitar saída colorida |
+| `TERM` | Defina como `dumb` para desabilitar saída colorida |
+| `TZ` | Define fuso horário |
+| `EDITOR` | Editor para o comando `picoclaw mcp edit` |
+| `GATEWAY_HOST` | Endereço de host do gateway (pode ser sobrescrito pelo flag `--host`) |
+
+---
+
+## Arquivo de Configuração
+
+O arquivo de configuração do PicoClaw está localizado em `~/.picoclaw/config.json` por padrão. Você pode visualizar e editar com:
+
+```bash
+# Mostrar caminho da configuração
+picoclaw status
+
+# Editar configuração
+picoclaw mcp edit
+```
+
+---
 
 ## Parâmetros do `picoclaw-launcher`
+
+O binário `picoclaw-launcher` fornece o launcher GUI com os seguintes parâmetros:
 
 | Parâmetro | Descrição | Exemplo |
 | --- | --- | --- |
 | `-console` | Executa no terminal (sem GUI de bandeja), imprime dica de login/origem do token no startup | `picoclaw-launcher -console` |
 | `-public` | Escuta em `0.0.0.0`, permite acesso ao WebUI por dispositivos na LAN | `picoclaw-launcher -public` |
 | `-no-browser` | Não abre o navegador automaticamente ao iniciar | `picoclaw-launcher -no-browser` |
-| `-port &lt;port&gt;` | Define a porta do launcher (padrão `18800`) | `picoclaw-launcher -port 19999` |
-| `-lang &lt;en|zh&gt;` | Define o idioma da interface do launcher | `picoclaw-launcher -lang zh` |
+| `-port <port>` | Define a porta do launcher (padrão `18800`) | `picoclaw-launcher -port 19999` |
+| `-lang <en\|zh>` | Define o idioma da interface do launcher | `picoclaw-launcher -lang zh` |
 | `[config.json]` | Caminho posicional opcional para arquivo de configuração | `picoclaw-launcher ./config.json` |
 
 Combinações comuns:
@@ -36,4 +787,24 @@ picoclaw-launcher -console -no-browser -public
 
 # Porta customizada com arquivo de configuração explícito
 picoclaw-launcher -port 19999 ./config.json
+```
+
+---
+
+## Obtendo Ajuda
+
+Obtenha ajuda detalhada para qualquer comando:
+
+```bash
+picoclaw --help
+picoclaw <command> --help
+picoclaw <command> <subcommand> --help
+```
+
+Exemplos:
+
+```bash
+picoclaw mcp add --help
+picoclaw cron add --help
+picoclaw model add --help
 ```

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/chat-commands.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/chat-commands.md
@@ -136,3 +136,5 @@ Telegram 风格的 `/command@botname` 也会被解析为对应命令。
 `picoclaw onboard` · `picoclaw agent` · `picoclaw auth` · `picoclaw gateway` · `picoclaw status` · `picoclaw cron` · `picoclaw mcp` · `picoclaw migrate` · `picoclaw skills` · `picoclaw model` · `picoclaw update` · `picoclaw version`
 
 这些 CLI 命令与聊天命令是两套入口：CLI 通过终端执行，聊天命令通过 Telegram/Feishu/微信等 channel 消息触发。
+
+CLI 命令的详细文档请参阅 [CLI 命令与参数](/docs/configuration/cli-parameters)。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/cli-parameters.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/cli-parameters.md
@@ -1,31 +1,782 @@
-﻿---
+---
 id: cli-parameters
 title: CLI 命令与参数
 ---
 
 # CLI 命令与参数
 
-## 核心 CLI 命令
+PicoClaw 是一个轻量级的个人 AI 助手。本文档介绍其命令行界面（CLI）支持的所有命令和参数。
 
-| 命令 | 说明 |
-| --- | --- |
-| `picoclaw onboard` | 初始化配置和工作目录 |
-| `picoclaw agent -m "你好"` | 单次对话 |
-| `picoclaw agent` | 交互式对话模式 |
-| `picoclaw gateway` | 启动网关（用于聊天应用） |
-| `picoclaw status` | 显示状态 |
-| `picoclaw cron list` | 列出所有定时任务 |
-| `picoclaw cron add ...` | 添加定时任务 |
+:::tip
+聊天中的 slash 命令（如 `/help`、`/clear`）请参阅[聊天命令参考](/docs/chat-commands)。
+:::
+
+## 全局参数
+
+| 参数 | 说明 |
+|------|------|
+| `--no-color` | 禁用彩色输出（保留边框布局） |
+
+也可以通过环境变量 `NO_COLOR` 或 `TERM=dumb` 来禁用颜色。
+
+---
+
+## 命令一览
+
+| 命令 | 别名 | 说明 |
+|------|------|------|
+| [`picoclaw onboard`](#picoclaw-onboard) | `o` | 初始化配置和工作区 |
+| [`picoclaw agent`](#picoclaw-agent) | | 与 AI 代理交互 |
+| [`picoclaw auth`](#picoclaw-auth) | | 管理认证（登录、登出、状态） |
+| [`picoclaw gateway`](#picoclaw-gateway) | `g` | 启动 PicoClaw 网关 |
+| [`picoclaw status`](#picoclaw-status) | `s` | 显示 PicoClaw 状态 |
+| [`picoclaw cron`](#picoclaw-cron) | `c` | 管理定时任务 |
+| [`picoclaw mcp`](#picoclaw-mcp) | | 管理 MCP 服务器配置 |
+| [`picoclaw migrate`](#picoclaw-migrate) | | 从其他工具迁移到 PicoClaw |
+| [`picoclaw skills`](#picoclaw-skills) | | 管理技能 |
+| [`picoclaw model`](#picoclaw-model) | | 查看或更改默认模型 |
+| [`picoclaw update`](#picoclaw-update) | | 更新 PicoClaw |
+| [`picoclaw version`](#picoclaw-version) | `v` | 显示版本信息 |
+
+---
+
+## picoclaw onboard
+
+初始化 PicoClaw 配置和工作区。
+
+```bash
+picoclaw onboard [flags]
+```
+
+### 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--enc` | 启用凭证加密（生成 SSH 密钥并提示输入密码） |
+
+### 示例
+
+```bash
+picoclaw onboard
+picoclaw onboard --enc
+```
+
+---
+
+## picoclaw agent
+
+直接与 AI 代理交互。
+
+```bash
+picoclaw agent [flags]
+```
+
+### 参数
+
+| 参数 | 短参数 | 默认值 | 说明 |
+|------|--------|--------|------|
+| `--debug` | `-d` | `false` | 启用调试日志 |
+| `--message` | `-m` | | 发送单条消息（非交互模式） |
+| `--session` | `-s` | `cli:default` | 会话密钥 |
+| `--model` | | | 使用的模型 |
+
+### 示例
+
+```bash
+# 交互模式
+picoclaw agent
+
+# 非交互模式
+picoclaw agent -m "Hello, how are you?"
+
+# 指定模型
+picoclaw agent --model gpt-5.2 -m "Explain quantum computing"
+```
+
+---
+
+## picoclaw auth
+
+管理认证，包括登录、登出和状态查看。
+
+```bash
+picoclaw auth [command]
+```
+
+### 子命令
+
+- [`login`](#picoclaw-auth-login) - 登录
+- [`logout`](#picoclaw-auth-logout) - 登出
+- [`status`](#picoclaw-auth-status) - 显示认证状态
+- [`models`](#picoclaw-auth-models) - 显示可用模型
+- [`weixin`](#picoclaw-auth-weixin) - 连接微信个人账号
+- [`wecom`](#picoclaw-auth-wecom) - 连接企业微信
+
+---
+
+### picoclaw auth login
+
+通过 OAuth 或粘贴令牌进行登录。
+
+```bash
+picoclaw auth login [flags]
+```
+
+#### 参数
+
+| 参数 | 短参数 | 说明 |
+|------|--------|------|
+| `--provider` | `-p` | **必需**。登录提供商（`openai`, `anthropic`, `google-antigravity`, `antigravity`） |
+| `--device-code` | | 使用设备代码流程（适用于无头环境） |
+| `--no-browser` | | OAuth 登录时不自动打开浏览器 |
+| `--setup-token` | | 使用 Anthropic 的 setup-token 流程 |
+
+#### 示例
+
+```bash
+picoclaw auth login -p openai
+picoclaw auth login -p anthropic --setup-token
+picoclaw auth login -p openai --device-code
+```
+
+---
+
+### picoclaw auth logout
+
+移除存储的凭证。
+
+```bash
+picoclaw auth logout [flags]
+```
+
+#### 参数
+
+| 参数 | 短参数 | 说明 |
+|------|--------|------|
+| `--provider` | `-p` | 要登出的提供商（`openai`, `anthropic`）；为空则登出所有 |
+
+#### 示例
+
+```bash
+picoclaw auth logout -p openai
+picoclaw auth logout
+```
+
+---
+
+### picoclaw auth status
+
+显示当前认证状态。
+
+```bash
+picoclaw auth status
+```
+
+---
+
+### picoclaw auth models
+
+显示可用模型。
+
+```bash
+picoclaw auth models
+```
+
+---
+
+### picoclaw auth weixin
+
+通过二维码连接微信个人账号。
+
+```bash
+picoclaw auth weixin [flags]
+```
+
+#### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--base-url` | `https://ilinkai.weixin.qq.com/` | iLink API 基础 URL |
+| `--proxy` | | HTTP 代理 URL（如 `http://localhost:7890`） |
+| `--timeout` | `300` | 登录超时时间（秒） |
+
+#### 示例
+
+```bash
+picoclaw auth weixin
+picoclaw auth weixin --proxy http://localhost:7890
+```
+
+---
+
+### picoclaw auth wecom
+
+扫描企业微信二维码并配置 `channels.wecom`。
+
+```bash
+picoclaw auth wecom [flags]
+```
+
+#### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--timeout` | `5m` | 等待二维码确认的超时时间 |
+
+#### 示例
+
+```bash
+picoclaw auth wecom
+picoclaw auth wecom --timeout 10m
+```
+
+---
+
+## picoclaw gateway
+
+启动 PicoClaw 网关服务。
+
+```bash
+picoclaw gateway [flags]
+```
+
+### 参数
+
+| 参数 | 短参数 | 默认值 | 说明 |
+|------|--------|--------|------|
+| `--debug` | `-d` | `false` | 启用调试日志 |
+| `--no-truncate` | `-T` | `false` | 禁用调试日志中的字符串截断（必须与 `--debug` 一起使用） |
+| `--allow-empty` | `-E` | `false` | 未配置默认模型时仍继续启动 |
+| `--host` | | | 网关绑定的主机地址（覆盖 `gateway.host` 配置） |
+
+### 示例
+
+```bash
+picoclaw gateway
+picoclaw gateway -d
+picoclaw gateway -d -T
+picoclaw gateway --host 0.0.0.0
+```
+
+---
+
+## picoclaw status
+
+显示 PicoClaw 当前状态。
+
+```bash
+picoclaw status
+```
+
+---
+
+## picoclaw cron
+
+管理定时任务。
+
+:::tip
+关于调度类型、执行模式和配置的详细文档，请参阅[定时任务与 Cron 作业](/docs/cron)。
+:::
+
+```bash
+picoclaw cron [command]
+```
+
+### 子命令
+
+- `list` - 列出所有定时任务
+- `add` - 添加新任务
+- `remove` - 按 ID 移除任务
+- `enable` - 启用任务
+- `disable` - 禁用任务
+
+### picoclaw cron add
+
+```bash
+picoclaw cron add [flags]
+```
+
+#### 参数
+
+| 参数 | 短参数 | 说明 |
+|------|--------|------|
+| `--name` | `-n` | **必需**。任务名称 |
+| `--message` | `-m` | **必需**。发送给代理的消息 |
+| `--every` | `-e` | 每 N 秒运行一次 |
+| `--cron` | `-c` | Cron 表达式（如 `0 9 * * *`） |
+| `--to` | | 接收者 |
+| `--channel` | | 投递渠道 |
+
+> **注意**：`--every` 和 `--cron` 互斥，必须指定其中一个。
+
+#### 示例
+
+```bash
+# 每 60 秒运行一次
+picoclaw cron add -n "health-check" -m "Check system health" -e 60
+
+# 每天早上 9 点运行
+picoclaw cron add -n "morning-report" -m "Generate morning report" -c "0 9 * * *"
+
+# 指定投递渠道
+picoclaw cron add -n "reminder" -m "Take a break" -e 1800 --channel wecom --to user123
+```
+
+### 其他 cron 子命令
+
+```bash
+picoclaw cron list
+picoclaw cron remove <job-id>
+picoclaw cron enable <job-id>
+picoclaw cron disable <job-id>
+```
+
+---
+
+## picoclaw mcp
+
+管理 MCP（Model Context Protocol）服务器配置。
+
+```bash
+picoclaw mcp [command]
+```
+
+### 子命令
+
+- [`add`](#picoclaw-mcp-add) - 添加或更新 MCP 服务器
+- [`remove`](#picoclaw-mcp-remove) - 移除 MCP 服务器
+- [`list`](#picoclaw-mcp-list) - 列出已配置的 MCP 服务器
+- [`edit`](#picoclaw-mcp-edit) - 在编辑器中打开配置
+- [`test`](#picoclaw-mcp-test) - 测试 MCP 服务器连接
+- [`show`](#picoclaw-mcp-show) - 显示 MCP 服务器详情
+
+---
+
+### picoclaw mcp add
+
+添加或更新 MCP 服务器。
+
+```bash
+picoclaw mcp add [flags] <name> <command-or-url> [args...]
+```
+
+#### 参数
+
+| 参数 | 短参数 | 默认值 | 说明 |
+|------|--------|--------|------|
+| `--env` | `-e` | | 环境变量，格式为 `KEY=value`（可重复） |
+| `--env-file` | | | 环境变量文件路径（推荐用于存储密钥） |
+| `--header` | `-H` | | HTTP 头，格式为 `Name: Value` 或 `Name=Value`（可重复） |
+| `--transport` | `-t` | `stdio` | 传输类型：`stdio`、`http` 或 `sse` |
+| `--force` | `-f` | `false` | 覆盖现有服务器而不提示 |
+| `--deferred` | | `false` | 标记为延迟加载（工具在显式激活前隐藏） |
+| `--no-deferred` | | `false` | 标记为非延迟加载（工具始终活跃） |
+
+#### 示例
+
+```bash
+# 添加 stdio 类型的 MCP 服务器
+picoclaw mcp add my-server /path/to/server arg1 arg2
+
+# 添加 http 类型的 MCP 服务器
+picoclaw mcp add remote-server https://example.com/mcp --transport http
+
+# 添加带环境变量的服务器
+picoclaw mcp add my-server /path/to/server -e API_KEY=xxx -e DEBUG=true
+
+# 使用环境变量文件
+picoclaw mcp add my-server /path/to/server --env-file .env
+
+# 强制覆盖
+picoclaw mcp add my-server /path/to/new-server --force
+```
+
+---
+
+### picoclaw mcp remove
+
+移除 MCP 服务器。
+
+```bash
+picoclaw mcp remove <name>
+```
+
+---
+
+### picoclaw mcp list
+
+列出已配置的 MCP 服务器。
+
+```bash
+picoclaw mcp list [flags]
+```
+
+#### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--status` | `false` | Ping 已启用的服务器并显示实时状态 |
+| `--timeout` | `5s` | 每次状态检查的超时时间 |
+
+#### 示例
+
+```bash
+picoclaw mcp list
+picoclaw mcp list --status
+picoclaw mcp list --status --timeout 10s
+```
+
+---
+
+### picoclaw mcp edit
+
+在 `$EDITOR` 中打开 PicoClaw 配置文件。
+
+```bash
+picoclaw mcp edit
+```
+
+> **注意**：需要设置 `EDITOR` 环境变量。
+
+---
+
+### picoclaw mcp test
+
+测试 MCP 服务器连接。
+
+```bash
+picoclaw mcp test <name> [flags]
+```
+
+#### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--timeout` | `5s` | 连接超时时间 |
+
+#### 示例
+
+```bash
+picoclaw mcp test my-server
+picoclaw mcp test my-server --timeout 10s
+```
+
+---
+
+### picoclaw mcp show
+
+显示 MCP 服务器详情和工具列表。
+
+```bash
+picoclaw mcp show <name> [flags]
+```
+
+#### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--timeout` | `10s` | 连接超时时间 |
+
+#### 示例
+
+```bash
+picoclaw mcp show my-server
+picoclaw mcp show my-server --timeout 15s
+```
+
+---
+
+## picoclaw migrate
+
+从其他工具（如 OpenClaw）迁移到 PicoClaw。
+
+```bash
+picoclaw migrate [flags]
+```
+
+### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--dry-run` | `false` | 显示将要迁移的内容，但不执行更改 |
+| `--from` | `openclaw` | 迁移来源（如 `openclaw`） |
+| `--refresh` | `false` | 从 OpenClaw 重新同步工作区文件 |
+| `--config-only` | `false` | 仅迁移配置，跳过工作区文件 |
+| `--workspace-only` | `false` | 仅迁移工作区文件，跳过配置 |
+| `--force` | `false` | 跳过确认提示 |
+| `--source-home` | `~/.openclaw` | 覆盖源目录 |
+| `--target-home` | `~/.picoclaw` | 覆盖目标目录 |
+
+### 示例
+
+```bash
+# 默认迁移
+picoclaw migrate
+
+# 预览迁移
+picoclaw migrate --dry-run
+
+# 仅迁移配置
+picoclaw migrate --config-only
+
+# 强制迁移
+picoclaw migrate --force
+```
+
+---
+
+## picoclaw skills
+
+管理技能。
+
+```bash
+picoclaw skills [command]
+```
+
+### 子命令
+
+- [`list`](#picoclaw-skills-list) - 列出已安装的技能
+- [`install`](#picoclaw-skills-install) - 从 GitHub 或注册表安装技能
+- [`install-builtin`](#picoclaw-skills-install-builtin) - 安装所有内置技能
+- [`list-builtin`](#picoclaw-skills-list-builtin) - 列出可用的内置技能
+- [`remove`](#picoclaw-skills-remove) - 移除已安装的技能
+- [`search`](#picoclaw-skills-search) - 搜索可用技能
+- [`show`](#picoclaw-skills-show) - 显示技能详情
+
+---
+
+### picoclaw skills list
+
+列出已安装的技能。
+
+```bash
+picoclaw skills list
+```
+
+---
+
+### picoclaw skills install
+
+从 GitHub 或注册表安装技能。
+
+```bash
+picoclaw skills install <github> [flags]
+picoclaw skills install --registry <name> <slug>
+```
+
+#### 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--registry` | 从指定注册表安装 |
+
+#### 示例
+
+```bash
+# 从 GitHub 安装
+picoclaw skills install sipeed/picoclaw-skills/weather
+
+# 从注册表安装
+picoclaw skills install --registry clawhub github
+```
+
+---
+
+### picoclaw skills install-builtin
+
+安装所有内置技能到工作区。
+
+```bash
+picoclaw skills install-builtin
+```
+
+---
+
+### picoclaw skills list-builtin
+
+列出可用的内置技能。
+
+```bash
+picoclaw skills list-builtin
+```
+
+---
+
+### picoclaw skills remove
+
+移除已安装的技能。
+
+```bash
+picoclaw skills remove <name>
+```
+
+> **别名**：`rm`, `uninstall`
+
+#### 示例
+
+```bash
+picoclaw skills remove weather
+picoclaw skills rm weather
+picoclaw skills uninstall weather
+```
+
+---
+
+### picoclaw skills search
+
+搜索可用技能。
+
+```bash
+picoclaw skills search [query]
+```
+
+#### 示例
+
+```bash
+# 列出所有技能
+picoclaw skills search
+
+# 搜索特定技能
+picoclaw skills search weather
+```
+
+---
+
+### picoclaw skills show
+
+显示技能详情。
+
+```bash
+picoclaw skills show <name>
+```
+
+#### 示例
+
+```bash
+picoclaw skills show weather
+```
+
+---
+
+## picoclaw model
+
+查看或更改默认模型。
+
+```bash
+picoclaw model [model_name] [command]
+```
+
+### 参数
+
+| 参数 | 说明 |
+|------|------|
+| `model_name` | 可选。要设置为默认的模型名称 |
+
+### 子命令
+
+- [`add`](#picoclaw-model-add) - 从 OpenAI 兼容端点添加模型
+
+### 示例
+
+```bash
+# 显示当前默认模型
+picoclaw model
+
+# 设置默认模型
+picoclaw model gpt-5.2
+picoclaw model claude-sonnet-4.6
+picoclaw model local-model
+```
+
+---
+
+### picoclaw model add
+
+从 OpenAI 兼容端点添加模型并设置为默认。
+
+```bash
+picoclaw model add [flags]
+```
+
+#### 参数
+
+| 参数 | 短参数 | 默认值 | 说明 |
+|------|--------|--------|------|
+| `--api-base` | `-b` | | **必需**。API 基础 URL |
+| `--api-key` | `-k` | | **必需**。API 密钥 |
+| `--model` | `-m` | | 模型 ID；设置后跳过交互式选择和网络调用 |
+| `--name` | `-n` | `custom-prefer` | 本地别名，写入 model_list 并用作默认模型名称 |
+| `--type` | | `openai-compatible` | 端点类型（目前仅支持 `openai-compatible`） |
+
+#### 示例
+
+```bash
+# 交互式选择模型
+picoclaw model add -b https://api.openai.com/v1 -k sk-xxx
+
+# 直接指定模型
+picoclaw model add -b http://localhost:8000/v1 -k dummy -m my-model -n local
+```
+
+---
+
+## picoclaw update
+
+更新 PicoClaw 到最新版本。
+
+```bash
+picoclaw update
+```
+
+---
+
+## picoclaw version
+
+显示版本信息。
+
+```bash
+picoclaw version
+```
+
+---
+
+## 环境变量
+
+| 变量 | 说明 |
+|------|------|
+| `NO_COLOR` | 设置为任意非空值以禁用彩色输出 |
+| `TERM` | 设置为 `dumb` 以禁用彩色输出 |
+| `TZ` | 设置时区 |
+| `EDITOR` | 用于 `picoclaw mcp edit` 命令的编辑器 |
+| `GATEWAY_HOST` | 网关绑定的主机地址（可被 `--host` 参数覆盖） |
+
+---
+
+## 配置文件
+
+PicoClaw 的配置文件默认位于 `~/.picoclaw/config.json`。可以使用以下命令查看和编辑：
+
+```bash
+# 查看配置路径
+picoclaw status
+
+# 编辑配置
+picoclaw mcp edit
+```
+
+---
 
 ## `picoclaw-launcher` 参数说明
+
+`picoclaw-launcher` 二进制提供 GUI 启动器，支持以下参数：
 
 | 参数 | 作用 | 示例 |
 | --- | --- | --- |
 | `-console` | 终端模式运行（不启用托盘 GUI），并在启动输出中打印登录提示和令牌来源 | `picoclaw-launcher -console` |
 | `-public` | 监听 `0.0.0.0`，允许局域网设备访问 WebUI | `picoclaw-launcher -public` |
 | `-no-browser` | 启动时不自动打开浏览器 | `picoclaw-launcher -no-browser` |
-| `-port &lt;port&gt;` | 指定端口（默认 `18800`） | `picoclaw-launcher -port 19999` |
-| `-lang &lt;en|zh&gt;` | 指定 UI 语言 | `picoclaw-launcher -lang zh` |
+| `-port <port>` | 指定端口（默认 `18800`） | `picoclaw-launcher -port 19999` |
+| `-lang <en\|zh>` | 指定 UI 语言 | `picoclaw-launcher -lang zh` |
 | `[config.json]` | 可选：指定配置文件路径 | `picoclaw-launcher ./config.json` |
 
 常见组合：
@@ -36,4 +787,24 @@ picoclaw-launcher -console -no-browser -public
 
 # 自定义端口 + 指定配置文件
 picoclaw-launcher -port 19999 ./config.json
+```
+
+---
+
+## 更多帮助
+
+获取任何命令的详细帮助：
+
+```bash
+picoclaw --help
+picoclaw <command> --help
+picoclaw <command> <subcommand> --help
+```
+
+例如：
+
+```bash
+picoclaw mcp add --help
+picoclaw cron add --help
+picoclaw model add --help
 ```


### PR DESCRIPTION
## Summary

- Expand `cli-parameters` page from a brief 7-row command table to a full CLI reference covering all 12 commands, subcommands, flags, and examples
- Add cross-references from `chat-commands.md` to the CLI reference page
- Update all three locales: en, zh-Hans, pt-BR

## Changes

| File | Change |
|---|---|
| `docs/configuration/cli-parameters.md` | Full CLI reference (EN) |
| `i18n/zh-Hans/.../cli-parameters.md` | Full CLI reference (ZH-Hans) |
| `i18n/pt-BR/.../cli-parameters.md` | Full CLI reference (PT-BR) |
| `docs/chat-commands.md` | Add link to CLI reference |
| `i18n/zh-Hans/.../chat-commands.md` | Add link to CLI reference |
| `i18n/pt-BR/.../chat-commands.md` | Add link to CLI reference |

## Notes

- Preserved the existing `picoclaw-launcher` section (unique to this page)
- Added `:::tip` boxes linking to `cron.md` and `chat-commands.md` to avoid content duplication
- Build passes for all 3 locales (en, zh-Hans, pt-BR)
- `CLI-REFERENCE.md` at project root can be removed in a follow-up once this is merged