### PR TITLE
fix: use pathname:// for install_picoclaw.py links to prevent webpack hash

### DIFF
--- a/docs/installation/licheervnano.md
+++ b/docs/installation/licheervnano.md
@@ -21,7 +21,7 @@ Make sure your host machine and the LicheeRV Nano are on the same LAN, then conn
 
 ### Method 1: One-click install script (recommended)
 
-Use `curl` to download and run the [`install_picoclaw.py`](/scripts/maixcam/install_picoclaw.py) script in one step:
+Use `curl` to download and run the [`install_picoclaw.py`](pathname:///scripts/maixcam/install_picoclaw.py) script in one step:
 
 ```bash
 curl -o install_picoclaw.py https://raw.githubusercontent.com/sipeed/picoclaw_docs/main/static/scripts/maixcam/install_picoclaw.py && python3 install_picoclaw.py

--- a/docs/installation/maixcam.md
+++ b/docs/installation/maixcam.md
@@ -85,7 +85,7 @@ Then open `http://<device-ip>:18800` in a browser on the same LAN.
 1. Connect to your MaixCam or MaixCam2 device in MaixVision.
 2. In MaixVision, create a new Python file and paste the script content below:
 
-	Script: [`install_picoclaw.py`](/scripts/maixcam/install_picoclaw.py)
+	Script: [`install_picoclaw.py`](pathname:///scripts/maixcam/install_picoclaw.py)
 
 3. Click **Run**. PicoClaw will be downloaded and installed on the device, and the PicoClaw Web UI will start.
 4. Open `http://<device-ip>:18800` in a browser on the same LAN to access the PicoClaw Web UI.

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/installation/licheervnano.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/installation/licheervnano.md
@@ -21,7 +21,7 @@ Certifique-se de que sua máquina host e a LicheeRV Nano estão na mesma LAN e, 
 
 ### Método 1: Script de instalação em um clique (recomendado)
 
-Use `curl` para baixar e executar o script [`install_picoclaw.py`](/scripts/maixcam/install_picoclaw.py) em uma única etapa:
+Use `curl` para baixar e executar o script [`install_picoclaw.py`](pathname:///scripts/maixcam/install_picoclaw.py) em uma única etapa:
 
 ```bash
 curl -o install_picoclaw.py https://raw.githubusercontent.com/sipeed/picoclaw_docs/main/static/scripts/maixcam/install_picoclaw.py && python3 install_picoclaw.py

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/installation/maixcam.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/installation/maixcam.md
@@ -85,7 +85,7 @@ Em seguida, abra `http://<device-ip>:18800` em um navegador na mesma LAN.
 1. Conecte-se ao seu dispositivo MaixCam ou MaixCam2 no MaixVision.
 2. No MaixVision, crie um novo arquivo Python e cole o conteúdo do script abaixo:
 
-	Script: [`install_picoclaw.py`](/scripts/maixcam/install_picoclaw.py)
+	Script: [`install_picoclaw.py`](pathname:///scripts/maixcam/install_picoclaw.py)
 
 3. Clique em **Run**. O PicoClaw será baixado e instalado no dispositivo, e a Web UI do PicoClaw será iniciada.
 4. Abra `http://<device-ip>:18800` em um navegador na mesma LAN para acessar a Web UI do PicoClaw.

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/licheervnano.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/licheervnano.md
@@ -23,7 +23,7 @@ LicheeRV Nano 的更多详细信息，请参考 [Sipeed 官方文档](https://wi
 
 ### 方式一：一键安装脚本（推荐）
 
-您可以使用 `curl` 命令一键下载并执行 [`install_picoclaw.py`](/scripts/maixcam/install_picoclaw.py) 安装脚本，免去手动分步操作的繁琐：
+您可以使用 `curl` 命令一键下载并执行 [`install_picoclaw.py`](pathname:///scripts/maixcam/install_picoclaw.py) 安装脚本，免去手动分步操作的繁琐：
 
 ```bash
 curl -o install_picoclaw.py https://raw.githubusercontent.com/sipeed/picoclaw_docs/main/static/scripts/maixcam/install_picoclaw.py && python3 install_picoclaw.py

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/maixcam.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/maixcam.md
@@ -85,7 +85,7 @@ picoclaw-launcher -no-browser -public
 1. 使用 MaixVision 连接上 MaixCam 或 MaixCam2 设备。
 2. 在 MaixVision 中创建一个新的 Python 文件，并写入以下脚本内容：
 
-   脚本地址：[`install_picoclaw.py`](/scripts/maixcam/install_picoclaw.py)
+   脚本地址：[`install_picoclaw.py`](pathname:///scripts/maixcam/install_picoclaw.py)
 
 3. 点击运行，PicoClaw 将会被下载并安装到设备上，并启动 PicoClaw 的 Web UI 界面。
 4. 在同一个局域网的浏览器中访问 `http://<设备IP>:18800` 即可进入 PicoClaw 的 Web UI。


### PR DESCRIPTION
## Problem

Clicking the `install_picoclaw.py` link redirects to `/assets/files/install_picoclaw-<hash>.py/` (404) because Docusaurus processes static file links via webpack, appending a content hash and a trailing slash (due to `trailingSlash: true`).

## Fix

Replace `/scripts/maixcam/install_picoclaw.py` with `pathname:///scripts/maixcam/install_picoclaw.py` in all affected files. The `pathname://` protocol tells Docusaurus to skip asset processing and link directly to the file in the `static/` directory.

## Files changed

- `docs/installation/maixcam.md`
- `docs/installation/licheervnano.md`
- `i18n/zh-Hans/.../maixcam.md`
- `i18n/zh-Hans/.../licheervnano.md`
- `i18n/pt-BR/.../maixcam.md`
- `i18n/pt-BR/.../licheervnano.md`