### PR TITLE
docs: add v0.3.0 changelog (en, zh-Hans, pt-BR)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,88 @@ All notable changes to PicoClaw are documented here.
 
 ---
 
+## v0.2.9
+
+*Released: 2026-05-24*
+
+### Highlights
+
+- **Multi-Agent Collaboration**: Agent discovery prompts, cross-agent delegation, and task dispatch via TargetAgentID (#2158, #2531)
+- **Provider Ecosystem Expansion**: Added gpt4free, SiliconFlow, and Gemini Web Search providers; unified provider metadata and backend catalog (#2909, #2885, #2763, #2701, #2896)
+- **Web Console Major Enhancement**: Model catalog browsing, provider connectivity verification, chat detail visibility selector, code block collapse/copy controls, and MCP config UI (#2831, #2832, #2833, #2886, #2882, #2770)
+- **MCP Streamable HTTP**: Added Streamable HTTP transport for MCP protocol (#2811)
+- **Agent Self-Evolution**: Runtime self-evolution configuration for automatic behavior optimization (#2847)
+- **LINE SDK Migration**: Migrated from hand-rolled HTTP code to official LINE Bot SDK v8 (#2413)
+
+### Features
+
+#### Core & Agent
+- Multi-agent discovery prompt with per-agent configuration (#2158)
+- Cross-agent delegation tool (delegate-tool) with TargetAgentID routing (#2531)
+- Agent self-evolution mechanism for runtime strategy optimization (#2847)
+- Request-scoped context policies for per-request dynamic Agent behavior (#2914)
+- AGENT.md frontmatter capability declarations for identity and capability discovery (#2158)
+- MCP allowlist mechanism — only whitelisted MCP servers are loaded (#2158)
+
+#### Providers & Models
+- gpt4free OpenAI-compatible provider (#2909)
+- SiliconFlow provider support (#2885)
+- Gemini Web Search provider (#2763)
+- Explicit provider metadata management with unified backend catalog (#2701, #2896)
+- Bedrock streaming inference (#2645)
+- Streaming transport support (#2892)
+- Persisted `model_name` in chat history for cross-session model tracking (#2897)
+
+#### Web Console
+- Model catalog browsing and provider selection form (#2831, #2832)
+- Real connectivity verification for providers (#2833)
+- Chat detail visibility selector (#2886)
+- Independent code block copy and collapse controls (#2882)
+- MCP configuration management UI (#2770)
+- Fetch models using stored API key for saved providers (#2910)
+- File diff preview (#2857)
+
+#### Channels
+- LINE channel migrated to official LINE Bot SDK v8 (#2413)
+- Slack Webhook Channel support (#2719)
+- Telegram media group support (#2758)
+- Factory reset feature (#2891)
+
+#### MCP Protocol
+- Streamable HTTP transport support (#2811)
+- Stop command support (#2762)
+
+### Bug Fixes
+
+- Fixed explicit thinking-off not being honored (#2898)
+- Fixed MiMo reasoning history replay (#2862)
+- Fixed DeepSeek stream reasoning_content loss (#2741)
+- Fixed leaf summary target validation (#2767)
+- Fixed Windows PowerShell encoding bypass injection vulnerability (#2836)
+- Fixed HTTP environment copy button compatibility (#2712)
+- Fixed `load_image` not being configurable (#2879)
+- Fixed Pico attachment image media loss across clients (#2874)
+- Fixed Telegram SVG media handling (#2773)
+- Fixed voice message reload media store (#2783)
+- Fixed parent session tool feedback cleanup (#2823)
+- Fixed queued voice followup processing (#2828)
+- Fixed network error retry logic (#2669)
+- Fixed i18n locale string sync for model provider UI (#2911)
+- Fixed Gemini MCP schema sanitization (#2681)
+- Fixed DeepSeek vision unsupported error message (#2717)
+- Fixed Baidu Search free tier documentation (1000/day → 1500/month) (#2825)
+
+### Build & Ops
+
+- Go bumped to 1.25.10 to fix stdlib vulnerabilities (#2818)
+- Added Portuguese (Brazil) full localization (#2037)
+- Multiple Go module upgrades: slack-go, gronx, x/net, telego, lark SDK, sqlite, systray, jsonschema-go, AWS SDK
+- Multiple frontend dependency upgrades: tailwindcss 4.3.0, shadcn 4.7.0, vite, i18next, react-i18next, jotai, typescript-eslint
+
+### Full changelog
+- [GitHub v0.2.8...v0.2.9](https://github.com/sipeed/picoclaw/compare/v0.2.8...v0.2.9)
+---
+
 ## v0.2.8
 
 *Released: 2026-04-30*

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,72 @@ All notable changes to PicoClaw are documented here.
 
 ---
 
+## v0.3.0
+
+*Released: 2026-06-15*
+
+### Highlights
+
+- **Reliability & Hardening**: Sweeping robustness pass across agent, tools, channels, and context — safe type-assertion guards, explicit `Close()` error handling, panic-safety, and transient LLM error retry (#2991)
+- **Provider Expansion**: Native Kagi web search provider and Azure OpenAI managed-identity (Entra ID) authentication (#3037, #2971)
+- **Web Console**: Chat image paste and drag-and-drop upload, code block line numbers with wrap toggle, and a shift-enter composer hint (#2933)
+- **Cron Tool**: Added `get` and `update` actions with per-channel access control
+- **Security**: Launcher access-control hardening, SSRF guard extended to 198.18.0.0/15, and scheme-less URL workspace guard (#3085)
+
+### Features
+
+#### Providers & Models
+- Native Kagi web search provider (#3037)
+- Azure OpenAI managed identity (Entra ID) authentication (#2971)
+- DeepSeek thinking-field mapping for OpenAI-compatible streaming (#2928)
+- CommonModels catalog for the MiMo provider (#2915)
+- Canonical Claude Sonnet model ID (#3036)
+
+#### Web Console
+- Chat image paste and drag-and-drop upload (#2939)
+- Code block line numbers and wrap toggle (#2933)
+- Shift-enter hint below the chat composer
+
+#### Core & Agent
+- Cron tool `get`/`update` actions with per-channel access restriction
+- Outbound message tool supports media attachments
+- Per-message `created_at` timestamps preserved across history bootstrap (#2946)
+- Audio-stream-only backpressure drop budget on the message bus
+- Transient LLM error retry (#2991)
+- PicoClaw agent skill expansion (#2994)
+
+#### Channels
+- Larksuite (Feishu) adapted to oapi-sdk-go v3.9.4 (#3008)
+
+#### Internationalization
+- Czech (cs) locale (#2932)
+- Bangla (bn-IN) locale (#2974)
+
+### Bug Fixes
+
+- Fixed agent loop stability by replacing WaitGroup with a Cond-based counter (#2904)
+- Fixed health check always returning not-ready
+- Fixed streamed Codex tool calls being dropped (#3007)
+- Fixed OneBot group reply routing via prefixed chatID (#3009)
+- Fixed OneBot private inbound media being fetched
+- Fixed Discord image download
+- Fixed Telegram location message handling (#3052)
+- Fixed exec tool rejecting workspace-relative paths (#3087)
+- Fixed `os.Root` API behavior on Windows (#3089)
+- Fixed `dm_scope` persistence and runtime session isolation (#3067)
+- Fixed launcher allowlist bypass and trusted-proxy client IP parsing
+- Fixed sogou search regex for new HTML structure (#3139)
+- Hardened type assertions and `Close()` error handling across agent, tools, channels, context, config, seahorse, and updater
+
+### Build & Ops
+
+- Go bumped to 1.25.11 (#2997)
+- modelcontextprotocol/go-sdk upgraded to 1.6.1
+
+### Full changelog
+- [GitHub v0.2.9...v0.3.0](https://github.com/sipeed/picoclaw/compare/v0.2.9...v0.3.0)
+---
+
 ## v0.2.9
 
 *Released: 2026-05-24*

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/changelog.md
@@ -9,6 +9,88 @@ Todas as mudanças notáveis do PicoClaw são documentadas aqui.
 
 ---
 
+## v0.2.9
+
+*Lançado: 2026-05-24*
+
+### Destaques
+
+- **Colaboração Multi-Agent**: Prompts de descoberta de Agent, delegação entre Agents e dispatch de tarefas via TargetAgentID (#2158, #2531)
+- **Expansão do ecossistema de Providers**: Novos providers gpt4free, SiliconFlow e Gemini Web Search; metadados e catálogo backend unificados (#2909, #2885, #2763, #2701, #2896)
+- **Console Web aprimorado**: Navegação em catálogo de modelos, verificação de conectividade de provider, seletor de visibilidade de detalhes do chat, controles de colapso/cópia de blocos de código e UI de configuração MCP (#2831, #2832, #2833, #2886, #2882, #2770)
+- **MCP Streamable HTTP**: Novo transporte Streamable HTTP para o protocolo MCP (#2811)
+- **Auto-evolução do Agent**: Configuração de auto-evolução em runtime para otimização automática de comportamento (#2847)
+- **Migração do LINE SDK**: Migração de código HTTP manual para o SDK oficial LINE Bot v8 (#2413)
+
+### Funcionalidades
+
+#### Core & Agent
+- Prompt de descoberta multi-agent com configuração independente por agent (#2158)
+- Ferramenta de delegação entre agents (delegate-tool) com roteamento por TargetAgentID (#2531)
+- Mecanismo de auto-evolução do Agent para otimização de estratégias em runtime (#2847)
+- Políticas de contexto por requisição para ajuste dinâmico do comportamento do Agent (#2914)
+- Declarações de capacidades via frontmatter do AGENT.md para descoberta de identidade (#2158)
+- Mecanismo de allowlist para MCP — apenas servidores MCP permitidos são carregados (#2158)
+
+#### Providers e Modelos
+- Provider gpt4free compatível com OpenAI (#2909)
+- Suporte ao provider SiliconFlow (#2885)
+- Provider Gemini Web Search (#2763)
+- Gerenciamento explícito de metadados de provider com catálogo backend unificado (#2701, #2896)
+- Inferência streaming Bedrock (#2645)
+- Suporte a transporte streaming (#2892)
+- Persistência de `model_name` no histórico de chat para rastreamento de modelo entre sessões (#2897)
+
+#### Console Web
+- Navegação em catálogo de modelos e formulário de seleção de provider (#2831, #2832)
+- Verificação real de conectividade para providers (#2833)
+- Seletor de visibilidade de detalhes do chat (#2886)
+- Controles independentes de cópia e colapso de blocos de código (#2882)
+- UI de gerenciamento de configuração MCP (#2770)
+- Busca de modelos usando API key armazenada para providers salvos (#2910)
+- Pré-visualização de diff de arquivos (#2857)
+
+#### Canais
+- Canal LINE migrado para o SDK oficial LINE Bot v8 (#2413)
+- Suporte ao canal Slack Webhook (#2719)
+- Suporte a grupo de mídia no Telegram (#2758)
+- Funcionalidade de reset de fábrica (#2891)
+
+#### Protocolo MCP
+- Suporte a transporte Streamable HTTP (#2811)
+- Suporte ao comando stop (#2762)
+
+### Correções de Bugs
+
+- Correção do thinking-off explícito não sendo respeitado (#2898)
+- Correção do replay de histórico de raciocínio MiMo (#2862)
+- Correção da perda de reasoning_content em streaming DeepSeek (#2741)
+- Correção da validação de alvo em resumo de nó folha (#2767)
+- Correção de vulnerabilidade de injeção via bypass de codificação PowerShell no Windows (#2836)
+- Correção de compatibilidade do botão de cópia em ambiente HTTP (#2712)
+- Correção do `load_image` não ser configurável (#2879)
+- Correção da perda de mídia de imagem de anexo Pico entre clientes (#2874)
+- Correção do tratamento de mídia SVG no Telegram (#2773)
+- Correção de reload de media store de mensagens de voz (#2783)
+- Correção da limpeza de feedback de ferramenta em sessão pai (#2823)
+- Correção do processamento de followups de voz em fila (#2828)
+- Correção da lógica de retentativa em erros de rede (#2669)
+- Correção da sincronização de strings de locale i18n para UI de provider de modelo (#2911)
+- Correção da sanitização de schema MCP Gemini (#2681)
+- Correção da mensagem de erro quando DeepSeek vision não é suportado (#2717)
+- Correção da documentação do tier gratuito Baidu Search (1000/dia → 1500/mês) (#2825)
+
+### Build e Ops
+
+- Go atualizado para 1.25.10 para correção de vulnerabilidades stdlib (#2818)
+- Adicionada localização completa em Português (Brasil) (#2037)
+- Múltiplos upgrades de módulos Go: slack-go, gronx, x/net, telego, Lark SDK, sqlite, systray, jsonschema-go, AWS SDK
+- Múltiplos upgrades de dependências frontend: tailwindcss 4.3.0, shadcn 4.7.0, vite, i18next, react-i18next, jotai, typescript-eslint
+
+### Changelog completo
+- [GitHub v0.2.8...v0.2.9](https://github.com/sipeed/picoclaw/compare/v0.2.8...v0.2.9)
+---
+
 ## v0.2.8
 
 *Lançado: 2026-04-30*

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/changelog.md
@@ -9,6 +9,72 @@ Todas as mudanças notáveis do PicoClaw são documentadas aqui.
 
 ---
 
+## v0.3.0
+
+*Lançado: 2026-06-15*
+
+### Destaques
+
+- **Confiabilidade e Robustez**: Ampla revisão de robustez em agent, tools, channels e context — guards seguros de type assertion, tratamento explícito de erros de `Close()`, proteção contra panic e retry de erros transitórios de LLM (#2991)
+- **Expansão de Providers**: Provider nativo de busca web Kagi e autenticação por managed identity (Entra ID) do Azure OpenAI (#3037, #2971)
+- **Console Web**: Colar e arrastar-e-soltar imagens no chat, números de linha em blocos de código com alternância de quebra e dica de shift-enter no compositor (#2933)
+- **Ferramenta Cron**: Adicionadas ações `get` e `update` com controle de acesso por channel
+- **Segurança**: Reforço do controle de acesso do launcher, guard de SSRF estendido para 198.18.0.0/15 e guard de workspace para URLs sem scheme (#3085)
+
+### Recursos
+
+#### Providers e Modelos
+- Provider nativo de busca web Kagi (#3037)
+- Autenticação por managed identity (Entra ID) do Azure OpenAI (#2971)
+- Mapeamento de campos de thinking do DeepSeek para streaming compatível com OpenAI (#2928)
+- Catálogo CommonModels para o provider MiMo (#2915)
+- ID canônico do modelo Claude Sonnet (#3036)
+
+#### Console Web
+- Colar e arrastar-e-soltar imagens no chat (#2939)
+- Números de linha e alternância de quebra em blocos de código (#2933)
+- Dica de shift-enter abaixo do compositor de chat
+
+#### Núcleo e Agent
+- Ações `get`/`update` da ferramenta cron com restrição de acesso por channel
+- Ferramenta de mensagem de saída suporta anexos de mídia
+- Timestamps `created_at` por mensagem preservados no bootstrap do histórico (#2946)
+- Orçamento de descarte por backpressure apenas para streams de áudio no message bus
+- Retry de erros transitórios de LLM (#2991)
+- Expansão de skills do agent PicoClaw (#2994)
+
+#### Channels
+- Larksuite (Feishu) adaptado para oapi-sdk-go v3.9.4 (#3008)
+
+#### Internacionalização
+- Locale tcheco (cs) (#2932)
+- Locale bengali (bn-IN) (#2974)
+
+### Correções de Bugs
+
+- Corrigida estabilidade do loop do agent substituindo WaitGroup por contador baseado em Cond (#2904)
+- Corrigido health check sempre retornando not-ready
+- Corrigida perda de chamadas de ferramenta em streaming do Codex (#3007)
+- Corrigido roteamento de resposta em grupo do OneBot via chatID prefixado (#3009)
+- Corrigido download de mídia de entrada privada do OneBot
+- Corrigido download de imagens do Discord
+- Corrigido tratamento de mensagens de localização do Telegram (#3052)
+- Corrigida ferramenta exec rejeitando caminhos relativos ao workspace (#3087)
+- Corrigido comportamento da API `os.Root` no Windows (#3089)
+- Corrigida persistência de `dm_scope` e isolamento de sessão em runtime (#3067)
+- Corrigido bypass de allowlist do launcher e parsing de IP de cliente via trusted-proxy
+- Corrigido regex de busca sogou para a nova estrutura HTML (#3139)
+- Reforçadas type assertions e tratamento de erros de `Close()` em agent, tools, channels, context, config, seahorse e updater
+
+### Build e Operações
+
+- Go atualizado para 1.25.11 (#2997)
+- modelcontextprotocol/go-sdk atualizado para 1.6.1
+
+### Changelog completo
+- [GitHub v0.2.9...v0.3.0](https://github.com/sipeed/picoclaw/compare/v0.2.9...v0.3.0)
+---
+
 ## v0.2.9
 
 *Lançado: 2026-05-24*

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/changelog.md
@@ -9,6 +9,89 @@ PicoClaw 的所有重要更新记录。
 
 ---
 
+## v0.2.9
+
+*发布日期：2026-05-24*
+
+### 核心亮点
+
+- **多 Agent 协作体系**：实现 Agent 发现提示词、跨 Agent 委托、任务分发等多 Agent 协作核心能力（#2158、#2531）
+- **Provider 生态扩展**：新增 gpt4free、SiliconFlow、Gemini Web Search 等 Provider，模型管理能力全面升级（#2909、#2885、#2763、#2701、#2896）
+- **Web 控制台大幅增强**：新增模型目录浏览、Provider 连通性验证、聊天详情可见性选择器、代码块折叠/复制等功能（#2831、#2832、#2833、#2886、#2882、#2770）
+- **MCP Streamable HTTP 支持**：MCP 协议新增 Streamable HTTP 传输支持（#2811）
+- **Agent 自进化能力**：支持 Agent 运行时自我进化配置，自动优化行为策略（#2847）
+- **LINE SDK 官方化**：从手写 HTTP 代码迁移至官方 LINE Bot SDK v8（#2413）
+
+### 功能
+
+#### 核心架构与 Agent
+- 新增多 Agent 发现提示词和按 Agent 独立配置能力（#2158）
+- 新增跨 Agent 委托工具（delegate-tool），支持 TargetAgentID 定向分发（#2531）
+- 新增 Agent 自进化机制，支持运行时策略自动优化（#2847）
+- 新增请求级上下文策略，支持按请求动态调整 Agent 行为（#2914）
+- Agent AGENT.md frontmatter 能力声明支持，自动发现身份和能力（#2158）
+- 新增 MCP 白名单机制，仅加载允许的 MCP 服务器（#2158）
+
+#### Provider 与模型
+- 新增 gpt4free OpenAI 兼容 Provider（#2909）
+- 新增 SiliconFlow Provider 支持（#2885）
+- 新增 Gemini Web Search Provider（#2763）
+- 新增 Provider 显式元数据管理，统一模型目录后端（#2701、#2896）
+- 新增 Bedrock 流式推理支持（#2645）
+- 新增流式传输支持（#2892）
+- 聊天历史持久化 model_name 字段，支持跨会话模型追踪（#2897）
+
+#### Web 控制台
+- 新增模型目录浏览和 Provider 选择表单（#2831、#2832）
+- 新增 Provider 真实连通性验证（#2833）
+- 新增聊天详情可见性选择器（#2886）
+- 新增独立代码块复制和折叠控件（#2882）
+- 新增 MCP 配置管理 UI（#2770）
+- 新增 Web 端 Provider 保存后模型拉取能力（#2910）
+- 新增文件差异预览能力（#2857）
+
+#### 渠道适配
+- LINE 渠道迁移至官方 LINE Bot SDK v8（#2413）
+- 新增 Slack Webhook Channel 支持（#2719）
+- 新增 Telegram 媒体组支持（#2758）
+- 新增恢复出厂设置功能（#2891）
+
+#### MCP 协议
+- 新增 MCP Streamable HTTP 传输支持（#2811）
+- 新增 stop 命令支持（#2762）
+
+### Bug 修复
+
+- 修复显式关闭 thinking 模式时未生效的问题（#2898）
+- 修复 MiMo 推理历史重放问题（#2862）
+- 修复 DeepSeek 流式推理内容（reasoning_content）丢失问题（#2741）
+- 修复叶子节点摘要目标验证问题（#2767）
+- 修复 Windows PowerShell 编码绕过注入安全漏洞（#2836）
+- 修复 HTTP 环境下复制按钮兼容性问题（#2712）
+- 修复 load_image 配置项不可配置的问题（#2879）
+- 修复 Pico 附件图片媒体在客户端间传递丢失的问题（#2874）
+- 修复 Telegram SVG 媒体处理问题（#2773）
+- 修复语音消息重载媒体存储问题（#2783）
+- 修复父会话工具反馈清理问题（#2823）
+- 修复排队语音后续处理问题（#2828）
+- 修复网络错误重试逻辑（#2669）
+- 修复模型 Provider UI 的 i18n 本地化字符串同步问题（#2911）
+- 修复 Gemini MCP Schema 清理问题（#2681）
+- 修复 DeepSeek vision 不支持时的错误提示（#2717）
+- 修复 Baidu Search 免费额度文档错误（1000/天 → 1500/月）（#2825）
+
+### 构建与运维
+
+- Go 升级至 1.25.10，修复 stdlib 安全漏洞（#2818）
+- 新增葡萄牙语（巴西）完整本地化支持（#2037）
+- 多项 Go 模块升级：slack-go、gronx、x/net、telego、飞书 SDK、sqlite、systray、jsonschema-go、AWS SDK
+- 多项前端依赖升级：tailwindcss 4.3.0、shadcn 4.7.0、vite、i18next、react-i18next、jotai、typescript-eslint
+
+### 完整变更
+- [GitHub v0.2.8...v0.2.9](https://github.com/sipeed/picoclaw/compare/v0.2.8...v0.2.9)
+
+---
+
 ## v0.2.8
 
 *发布日期：2026-04-30*

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/changelog.md
@@ -9,6 +9,72 @@ PicoClaw 的所有重要更新记录。
 
 ---
 
+## v0.3.0
+
+*发布日期：2026-06-15*
+
+### 核心亮点
+
+- **稳定性与健壮性加固**：覆盖 agent、tools、channels、context 的全面健壮性整治——安全的类型断言保护、显式 `Close()` 错误处理、防 panic，以及瞬态 LLM 错误重试（#2991）
+- **Provider 扩展**：新增原生 Kagi 网络搜索 Provider 和 Azure OpenAI 托管身份（Entra ID）认证（#3037、#2971）
+- **Web 控制台**：聊天图片粘贴与拖拽上传、代码块行号及换行切换、输入框 Shift+Enter 提示（#2933）
+- **Cron 工具**：新增 `get`/`update` 动作，支持按 channel 的访问控制
+- **安全**：Launcher 访问控制加固、SSRF 防护扩展至 198.18.0.0/15、无 scheme URL 的工作区防护（#3085）
+
+### 新功能
+
+#### Provider 与模型
+- 原生 Kagi 网络搜索 Provider（#3037）
+- Azure OpenAI 托管身份（Entra ID）认证（#2971）
+- DeepSeek thinking 字段映射（OpenAI 兼容流式）（#2928）
+- MiMo Provider 通用模型目录（#2915）
+- 规范化 Claude Sonnet 模型 ID（#3036）
+
+#### Web 控制台
+- 聊天图片粘贴与拖拽上传（#2939）
+- 代码块行号与换行切换（#2933）
+- 输入框下方 Shift+Enter 提示
+
+#### 核心与 Agent
+- Cron 工具 `get`/`update` 动作，按 channel 限制访问
+- 出站 message 工具支持媒体附件
+- 历史引导时保留每条消息的 `created_at` 时间戳（#2946）
+- 消息总线仅针对音频流的背压丢弃预算
+- 瞬态 LLM 错误重试（#2991）
+- PicoClaw agent 技能扩展（#2994）
+
+#### Channel
+- 飞书（Larksuite）适配 oapi-sdk-go v3.9.4（#3008）
+
+#### 本地化
+- 捷克语（cs）（#2932）
+- 孟加拉语（bn-IN）（#2974）
+
+### Bug 修复
+
+- 修复 agent loop 稳定性，以 Cond 计数器替代 WaitGroup（#2904）
+- 修复健康检查始终返回 not-ready
+- 修复 Codex 流式工具调用丢失（#3007）
+- 修复 OneBot 群聊回复路由（prefixed chatID）（#3009）
+- 修复 OneBot 私信入站媒体被下载
+- 修复 Discord 图片下载
+- 修复 Telegram 位置消息处理（#3052）
+- 修复 exec 工具拒绝工作区相对路径（#3087）
+- 修复 Windows 上 `os.Root` API 行为（#3089）
+- 修复 `dm_scope` 持久化与运行时会话隔离（#3067）
+- 修复 Launcher 白名单绕过与受信代理客户端 IP 解析
+- 修复 sogou 搜索正则以匹配新 HTML 结构（#3139）
+- 加固 agent、tools、channels、context、config、seahorse、updater 的类型断言与 `Close()` 错误处理
+
+### 构建与运维
+
+- Go 升级至 1.25.11（#2997）
+- modelcontextprotocol/go-sdk 升级至 1.6.1
+
+### 完整更新日志
+- [GitHub v0.2.9...v0.3.0](https://github.com/sipeed/picoclaw/compare/v0.2.9...v0.3.0)
+---
+
 ## v0.2.9
 
 *发布日期：2026-05-24*


### PR DESCRIPTION
Adds the v0.3.0 changelog entry in English, Simplified Chinese, and Brazilian Portuguese.

Highlights: reliability & hardening pass, native Kagi web search provider, Azure OpenAI managed identity, web console image paste/drag-drop, cron get/update actions, SSRF guard extension.

Note: stacked on #55 (v0.2.9). The diff will reduce to v0.3.0-only once #55 merges; rebase if needed.

Full changelog: https://github.com/sipeed/picoclaw/compare/v0.2.9...v0.3.0